### PR TITLE
Auth hardening: backend stubs, expiry enforcement, frontend protected…

### DIFF
--- a/backend/api-service/src/main/java/com/microtimemanagement/apiservice/controller/ActivityRecordController.java
+++ b/backend/api-service/src/main/java/com/microtimemanagement/apiservice/controller/ActivityRecordController.java
@@ -2,14 +2,17 @@ package com.microtimemanagement.apiservice.controller;
 
 import com.microtimemanagement.apiservice.constants.ApiConstants;
 import com.microtimemanagement.apiservice.dto.request.ActivityRecordCreationRequestDTO;
+import com.microtimemanagement.apiservice.dto.request.ActivityUpdateRequestDTO;
 import com.microtimemanagement.apiservice.dto.response.ActivityRecordCreationdResponseDTO;
 import com.microtimemanagement.apiservice.dto.response.ActivityRecordResponseDTO;
 import com.microtimemanagement.apiservice.exceptions.MicroTimeManagementBadRequestException;
 import com.microtimemanagement.apiservice.service.ActivityRecordService;
+import com.microtimemanagement.apiservice.utils.ApiUtils;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
 import java.text.ParseException;
@@ -48,9 +51,12 @@ public class ActivityRecordController {
     @RequestMapping(value = ApiConstants.EMPTY_BASE, method = RequestMethod.PUT)
     @ResponseBody
     public ActivityRecordResponseDTO updateActivity(
-            @RequestParam String date
+            @RequestParam String date,
+            @Valid @RequestBody ActivityUpdateRequestDTO updateRequest,
+            BindingResult bindingResult
     ){
-        return activityRecordService.updateActivity(date);
+        ApiUtils.handleValidationErrors(bindingResult);
+        return activityRecordService.updateActivity(date, updateRequest);
     }
 
 

--- a/backend/api-service/src/main/java/com/microtimemanagement/apiservice/dto/request/ActivityUpdateRequestDTO.java
+++ b/backend/api-service/src/main/java/com/microtimemanagement/apiservice/dto/request/ActivityUpdateRequestDTO.java
@@ -1,0 +1,28 @@
+package com.microtimemanagement.apiservice.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ActivityUpdateRequestDTO {
+
+    @NotBlank(message = "Activity id cannot be empty.")
+    private String recordId;
+
+    private String activityName;
+
+    private String activityDescription;
+
+    private String activityStartHourMinutes;
+
+    private String activityEndHourMinutes;
+
+    private Boolean isNextDaySpan;
+
+}

--- a/backend/api-service/src/main/java/com/microtimemanagement/apiservice/dto/request/RoleUpdateRequestDTO.java
+++ b/backend/api-service/src/main/java/com/microtimemanagement/apiservice/dto/request/RoleUpdateRequestDTO.java
@@ -1,5 +1,6 @@
 package com.microtimemanagement.apiservice.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Data;
 
@@ -7,8 +8,10 @@ import lombok.Data;
 @Builder
 public class RoleUpdateRequestDTO {
 
+    @NotBlank(message = "Role id cannot be empty.")
     public String roleId;
 
+    @NotBlank(message = "Role name cannot be empty.")
     public String roleName;
 
 }

--- a/backend/api-service/src/main/java/com/microtimemanagement/apiservice/filter/MtmSessionFilter.java
+++ b/backend/api-service/src/main/java/com/microtimemanagement/apiservice/filter/MtmSessionFilter.java
@@ -68,21 +68,34 @@ public class MtmSessionFilter extends OncePerRequestFilter {
                 }
             }
             filterChain.doFilter(request, response);
+        }catch (MicroTimeManagementAuthenticationException e){
+            log.info("Rejecting request to {}: {}", request.getServletPath(), e.getMessage());
+            writeErrorResponse(request, response, HttpStatus.UNAUTHORIZED, e.getMessage());
         }catch (Exception e){
-            e.printStackTrace();
-            Map<String, String> errors = new HashMap<>();
-            errors.put("message", e.getMessage());
-            response.setContentType("application/json");
-            response.setStatus(HttpStatus.FORBIDDEN.value());
-            response.getWriter().write(
-                    objectMapper.writeValueAsString(
-                            ExceptionDTO.builder()
-                                    .error(errors)
-                                    .path(request.getServletPath())
-                                    .statusCode(HttpStatus.FORBIDDEN.value())
-                                    .code(System.currentTimeMillis())
-                                    .build()
-                    ));
+            log.error("Unexpected error while authenticating request to {}", request.getServletPath(), e);
+            writeErrorResponse(request, response, HttpStatus.INTERNAL_SERVER_ERROR,
+                    "Unexpected error while authenticating request. Please contact dev.");
         }
+    }
+
+    private void writeErrorResponse(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            HttpStatus status,
+            String message
+    ) throws IOException {
+        Map<String, String> errors = new HashMap<>();
+        errors.put("message", message);
+        response.setContentType("application/json");
+        response.setStatus(status.value());
+        response.getWriter().write(
+                objectMapper.writeValueAsString(
+                        ExceptionDTO.builder()
+                                .error(errors)
+                                .path(request.getServletPath())
+                                .statusCode(status.value())
+                                .code(System.currentTimeMillis())
+                                .build()
+                ));
     }
 }

--- a/backend/api-service/src/main/java/com/microtimemanagement/apiservice/handler/MicroTimeManagementResourceExceptionHandler.java
+++ b/backend/api-service/src/main/java/com/microtimemanagement/apiservice/handler/MicroTimeManagementResourceExceptionHandler.java
@@ -27,9 +27,7 @@ public class MicroTimeManagementResourceExceptionHandler {
     @ExceptionHandler(value = {MicroTimeManagementBadRequestException.class})
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     private @ResponseBody ExceptionDTO<?> handleBadRequestException(MicroTimeManagementBadRequestException ex, ServletWebRequest webRequest){
-        System.out.println(webRequest.getRequest().getRequestURI());
-        System.out.println(webRequest.getUserPrincipal());
-        System.out.println(webRequest.getRequest().getServletPath());
+        log.debug("Bad request on {} for principal {}", webRequest.getRequest().getRequestURI(), webRequest.getUserPrincipal());
         log.error("{}", getBuilderForStackTrace(ex.getStackTrace()));
         return buildExceptionDTO(ex, webRequest, HttpStatus.BAD_REQUEST);
     }
@@ -37,9 +35,7 @@ public class MicroTimeManagementResourceExceptionHandler {
     @ExceptionHandler(value = {MicroTimeManagementNotFoundException.class})
     @ResponseStatus(HttpStatus.NOT_FOUND)
     private @ResponseBody ExceptionDTO<?> handleNotFoundException(MicroTimeManagementNotFoundException ex, ServletWebRequest webRequest){
-        System.out.println(webRequest.getRequest().getRequestURI());
-        System.out.println(webRequest.getUserPrincipal());
-        System.out.println(webRequest.getRequest().getServletPath());
+        log.debug("Resource not found on {} for principal {}", webRequest.getRequest().getRequestURI(), webRequest.getUserPrincipal());
         log.error("{}", getBuilderForStackTrace(ex.getStackTrace()));
         return buildExceptionDTO(ex, webRequest, HttpStatus.NOT_FOUND);
     }

--- a/backend/api-service/src/main/java/com/microtimemanagement/apiservice/model/RefreshToken.java
+++ b/backend/api-service/src/main/java/com/microtimemanagement/apiservice/model/RefreshToken.java
@@ -40,12 +40,13 @@ public class RefreshToken extends BaseModel{
     private Date expiresAt;
 
     public AccessToken getActiveAccessToken(){
-        if(null!=accessTokens)
-            return this.accessTokens
-                    .stream()
-                    .filter(accessToken -> accessToken.getIsActive().equals(Boolean.TRUE))
-                    .toList().get(0);
-        return null;
+        if(null == accessTokens)
+            return null;
+        return this.accessTokens
+                .stream()
+                .filter(accessToken -> Boolean.TRUE.equals(accessToken.getIsActive()))
+                .findFirst()
+                .orElse(null);
     }
 
 

--- a/backend/api-service/src/main/java/com/microtimemanagement/apiservice/service/ActivityRecordService.java
+++ b/backend/api-service/src/main/java/com/microtimemanagement/apiservice/service/ActivityRecordService.java
@@ -1,6 +1,7 @@
 package com.microtimemanagement.apiservice.service;
 
 import com.microtimemanagement.apiservice.dto.request.ActivityRecordCreationRequestDTO;
+import com.microtimemanagement.apiservice.dto.request.ActivityUpdateRequestDTO;
 import com.microtimemanagement.apiservice.dto.response.ActivityRecordCreationdResponseDTO;
 import com.microtimemanagement.apiservice.dto.response.ActivityRecordResponseDTO;
 import com.microtimemanagement.apiservice.model.ActivityRecord;
@@ -17,5 +18,5 @@ public interface ActivityRecordService {
 
     ActivityRecordResponseDTO deleteActivity(String date, String recordId);
 
-    ActivityRecordResponseDTO updateActivity(String date);
+    ActivityRecordResponseDTO updateActivity(String date, ActivityUpdateRequestDTO updateRequest);
 }

--- a/backend/api-service/src/main/java/com/microtimemanagement/apiservice/service/impl/AccessTokenServiceImpl.java
+++ b/backend/api-service/src/main/java/com/microtimemanagement/apiservice/service/impl/AccessTokenServiceImpl.java
@@ -127,6 +127,16 @@ public class AccessTokenServiceImpl implements AccessTokenService {
                     .build();
         }
 
+        if(null != accessTokenDTO.getExpiresAt()
+                && accessTokenDTO.getExpiresAt().getTime() <= System.currentTimeMillis()){
+            log.info("Access token expired at {}", accessTokenDTO.getExpiresAt());
+            return ValidSessionTokenDTO.builder()
+                    .isValidSession(Boolean.FALSE)
+                    .principal(null)
+                    .error(ErrorConstants.SESSION_EXPIRED)
+                    .build();
+        }
+
         return jsonWebTokenService.validateJwtSessionAccessToken(token);
     }
 }

--- a/backend/api-service/src/main/java/com/microtimemanagement/apiservice/service/impl/ActivityRecordServiceImpl.java
+++ b/backend/api-service/src/main/java/com/microtimemanagement/apiservice/service/impl/ActivityRecordServiceImpl.java
@@ -5,6 +5,7 @@ import com.microtimemanagement.apiservice.converter.ActivityDTOConverter;
 import com.microtimemanagement.apiservice.dto.entity.ActivityDTO;
 import com.microtimemanagement.apiservice.dto.entity.UserDTO;
 import com.microtimemanagement.apiservice.dto.request.ActivityRecordCreationRequestDTO;
+import com.microtimemanagement.apiservice.dto.request.ActivityUpdateRequestDTO;
 import com.microtimemanagement.apiservice.dto.response.ActivityRecordCreationdResponseDTO;
 import com.microtimemanagement.apiservice.dto.response.ActivityRecordResponseDTO;
 import com.microtimemanagement.apiservice.exceptions.MicroTimeManagementBadRequestException;
@@ -18,6 +19,7 @@ import com.microtimemanagement.apiservice.service.ActivityService;
 import com.microtimemanagement.apiservice.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.time.DateFormatUtils;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -172,8 +174,55 @@ public class ActivityRecordServiceImpl implements ActivityRecordService {
     }
 
     @Override
-    public ActivityRecordResponseDTO updateActivity(String date) {
-        return null;
+    public ActivityRecordResponseDTO updateActivity(String date, ActivityUpdateRequestDTO updateRequest) {
+        UserDTO userDTO = userService.loadUserDTOByUsername(
+                SecurityContextHolder.getContext().getAuthentication().getName()
+        );
+        ActivityRecord activityRecord = activityRecordRepository
+                .findByRecordDateAndCreatedBy(date, userDTO.getUid())
+                .orElseThrow(() -> new MicroTimeManagementNotFoundException(
+                        String.format("No record found for date %s", date)));
+
+        Activity existing = activityRecord.getActivities().stream()
+                .filter(a -> a.getId().equals(updateRequest.getRecordId()))
+                .findFirst()
+                .orElseThrow(() -> new MicroTimeManagementNotFoundException(ErrorConstants.ACTIVITY_NOT_FOUND));
+
+        boolean retime = StringUtils.isNotBlank(updateRequest.getActivityStartHourMinutes())
+                && StringUtils.isNotBlank(updateRequest.getActivityEndHourMinutes());
+
+        if (retime) {
+            // Remove the existing entry, then re-insert via the create pipeline so overlap
+            // validation and chronological ordering stay in one place.
+            activityRecord.getActivities().removeIf(a -> a.getId().equals(updateRequest.getRecordId()));
+            saveRecord(activityRecord);
+
+            ActivityRecordCreationRequestDTO creationDTO = new ActivityRecordCreationRequestDTO();
+            creationDTO.setRecordDate(date);
+            creationDTO.setActivityName(StringUtils.defaultIfBlank(
+                    updateRequest.getActivityName(), existing.getActivityName()));
+            creationDTO.setActivityDescription(StringUtils.defaultIfBlank(
+                    updateRequest.getActivityDescription(), existing.getActivityDescription()));
+            creationDTO.setActivityStartHourMinutes(updateRequest.getActivityStartHourMinutes());
+            creationDTO.setActivityEndHourMinutes(updateRequest.getActivityEndHourMinutes());
+            creationDTO.setIsNextDaySpan(Boolean.TRUE.equals(updateRequest.getIsNextDaySpan()));
+            try {
+                processCreateUpdateRequest(creationDTO);
+            } catch (MicroTimeManagementException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new MicroTimeManagementBadRequestException(ErrorConstants.INVALID_DATE_VALUE);
+            }
+        } else {
+            if (StringUtils.isNotBlank(updateRequest.getActivityName())) {
+                existing.setActivityName(updateRequest.getActivityName());
+            }
+            if (null != updateRequest.getActivityDescription()) {
+                existing.setActivityDescription(updateRequest.getActivityDescription());
+            }
+            saveRecord(activityRecord);
+        }
+        return getActivitiesForDate(date);
     }
 
     private ActivityRecord insertActivityInTimeRecordAtLocation(

--- a/backend/api-service/src/main/java/com/microtimemanagement/apiservice/service/impl/RoleServiceImpl.java
+++ b/backend/api-service/src/main/java/com/microtimemanagement/apiservice/service/impl/RoleServiceImpl.java
@@ -1,11 +1,14 @@
 package com.microtimemanagement.apiservice.service.impl;
 
+import com.microtimemanagement.apiservice.constants.ErrorConstants;
 import com.microtimemanagement.apiservice.constants.ResponseMessages;
 import com.microtimemanagement.apiservice.constants.RoleConstants;
 import com.microtimemanagement.apiservice.converter.RoleConverter;
 import com.microtimemanagement.apiservice.dto.entity.RoleDTO;
 import com.microtimemanagement.apiservice.dto.request.NewRoleRequestDTO;
 import com.microtimemanagement.apiservice.dto.request.RoleUpdateRequestDTO;
+import com.microtimemanagement.apiservice.exceptions.MicroTimeManagementBadRequestException;
+import com.microtimemanagement.apiservice.exceptions.MicroTimeManagementNotFoundException;
 import com.microtimemanagement.apiservice.model.Role;
 import com.microtimemanagement.apiservice.repository.RoleRepository;
 import com.microtimemanagement.apiservice.service.RoleService;
@@ -81,7 +84,20 @@ public class RoleServiceImpl implements RoleService {
      */
     @Override
     public RoleDTO updateRoleDetails(RoleUpdateRequestDTO roleUpdateRequestDTO) {
-        return null;
+        Role role = roleRepository.findByIdAndIsActiveTrue(roleUpdateRequestDTO.getRoleId());
+        if (null == role) {
+            throw new MicroTimeManagementNotFoundException(ErrorConstants.ROLE_NOT_FOUND_ERROR);
+        }
+        String newName = roleUpdateRequestDTO.getRoleName().trim();
+        if (newName.equals(role.getName())) {
+            return roleConverter.toDTO(role);
+        }
+        Role conflicting = roleRepository.findByNameAndIsActiveTrue(newName);
+        if (null != conflicting && !conflicting.getId().equals(role.getId())) {
+            throw new MicroTimeManagementBadRequestException(ErrorConstants.ACTIVE_ROLE_ALREADY_EXISTS_ERROR);
+        }
+        role.setName(newName);
+        return roleConverter.toDTO(saveRole(role));
     }
 
     /**

--- a/backend/api-service/src/main/java/com/microtimemanagement/apiservice/service/impl/UserServiceImpl.java
+++ b/backend/api-service/src/main/java/com/microtimemanagement/apiservice/service/impl/UserServiceImpl.java
@@ -93,7 +93,7 @@ public class UserServiceImpl implements UserService {
     private User findById(String id){
         Optional<User> user = userRepository.findById(id);
         if(user.isEmpty()){
-            throw new MicroTimeManagementUserException(ErrorConstants.USER_NOT_FOUND_IN_DB_RECORDS);
+            throw new MicroTimeManagementNotFoundException(ErrorConstants.USER_NOT_FOUND_IN_DB_RECORDS);
         }
         return user.get();
     }
@@ -104,14 +104,14 @@ public class UserServiceImpl implements UserService {
     private User findByUsername(String username){
         Optional<User> user = userRepository.findByUsernameAndIsActiveTrue(username);
         if(user.isEmpty()){
-            throw new MicroTimeManagementUserException(ErrorConstants.USER_NOT_FOUND_IN_DB_RECORDS);
+            throw new MicroTimeManagementNotFoundException(ErrorConstants.USER_NOT_FOUND_IN_DB_RECORDS);
         }
         return user.get();
     }
     private User findByEmail(String email){
         Optional<User> user = userRepository.findByEmailAndIsActiveTrue(email);
         if(user.isEmpty()){
-            throw new MicroTimeManagementUserException(ErrorConstants.USER_NOT_FOUND_IN_DB_RECORDS);
+            throw new MicroTimeManagementNotFoundException(ErrorConstants.USER_NOT_FOUND_IN_DB_RECORDS);
         }
         return user.get();}
 

--- a/backend/api-service/src/main/java/com/microtimemanagement/apiservice/utils/JwtUtils.java
+++ b/backend/api-service/src/main/java/com/microtimemanagement/apiservice/utils/JwtUtils.java
@@ -18,7 +18,7 @@ import java.util.Date;
 @Component
 public class JwtUtils {
 
-    @Value("${jwt.secret:secret}")
+    @Value("${jwt.secret}")
     private String key;
 
     private SecretKey getSigningKey(){

--- a/backend/api-service/src/main/resources/application-dev.yml
+++ b/backend/api-service/src/main/resources/application-dev.yml
@@ -21,4 +21,4 @@ logging:
   file:
     name: log/mtm_test.log
 jwt:
-  secret: "jnv89h4qp98hon98q34opf0934ur0f2iqk40if0935ut09843u908fu4309gh03589rjf0934j0fj304jf930j094f0934o"
+  secret: ${MTM_JWT_SECRET:jnv89h4qp98hon98q34opf0934ur0f2iqk40if0935ut09843u908fu4309gh03589rjf0934j0fj304jf930j094f0934o}

--- a/backend/api-service/src/main/resources/application-prod.yml
+++ b/backend/api-service/src/main/resources/application-prod.yml
@@ -14,3 +14,5 @@ springdoc:
 logging:
   file:
     name: ${LOG_FILE_PROPERTIES}
+jwt:
+  secret: ${MTM_JWT_SECRET}

--- a/frontend/src/Pages/App.js
+++ b/frontend/src/Pages/App.js
@@ -8,6 +8,8 @@ import Footer from "../components/Footer";
 import { Route, Routes } from "react-router-dom";
 import Login from "./Login";
 import Registration from "./Registration";
+import Dashboard from "./Dashboard";
+import ProtectedRoute from "../components/ProtectedRoute";
 import { useState } from "react";
 import Toast from "../components/Toast";
 
@@ -59,6 +61,14 @@ function App() {
               toastState={toastState}
               setToastState={setToastState}
             />
+          }
+        ></Route>
+        <Route
+          path={"/dashboard"}
+          element={
+            <ProtectedRoute>
+              <Dashboard />
+            </ProtectedRoute>
           }
         ></Route>
       </Routes>

--- a/frontend/src/Pages/Dashboard.js
+++ b/frontend/src/Pages/Dashboard.js
@@ -1,0 +1,16 @@
+import React from "react";
+
+function Dashboard() {
+  return (
+    <div className="mtm-min-h-[60vh] mtm-bg-black mtm-text-white mtm-py-20 mtm-px-8 mtm-text-center">
+      <h1 className="mtm-text-3xl mtm-tracking-wider mtm-text-sky-400">
+        Welcome back
+      </h1>
+      <p className="mtm-mt-4 mtm-text-white/70">
+        Activity tracking dashboard is coming soon.
+      </p>
+    </div>
+  );
+}
+
+export default Dashboard;

--- a/frontend/src/Pages/Login.js
+++ b/frontend/src/Pages/Login.js
@@ -1,11 +1,15 @@
 import React, { useRef } from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import Button from "../components/Button";
 import MtmForm from "../components/forms/MtmForm";
 import { loginUser } from "../service/ApiService";
 
 function Login({ toastState, setToastState }) {
   const navigate = useNavigate();
+  const location = useLocation();
+  const redirectTarget =
+    (location.state && location.state.from && location.state.from.pathname) ||
+    "/dashboard";
   const refCollection = {
     username: useRef(),
     password: useRef(),
@@ -50,7 +54,7 @@ function Login({ toastState, setToastState }) {
                   includeSuffix: true,
                   suffix: "Redirecting...",
                 });
-                setTimeout(() => navigate("/"), 1500);
+                setTimeout(() => navigate(redirectTarget, { replace: true }), 1500);
                 return;
               }
               if (errorResponse && errorResponse.error) {

--- a/frontend/src/components/NavigationBar.js
+++ b/frontend/src/components/NavigationBar.js
@@ -1,18 +1,26 @@
 import React, { useState } from "react";
 import mtm from "../Micro.gif";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import Nav from "react-bootstrap/Nav";
 import Navbar from "react-bootstrap/Navbar";
 import { Button } from "react-bootstrap";
 import { AiOutlineAlignCenter } from "react-icons/ai";
 import { BsCaretUpFill } from "react-icons/bs";
-import Home from "../Pages/Home";
+import useAuth from "../hooks/useAuth";
+import { logoutUser } from "../service/ApiService";
 
 const twButton =
   "mtm-animate-pulse mtm-text-white mtm-w-[130px] mtm-mt-[1%] sm:mtm-my-[0px] hover:mtm-bg-yellow-300 hover:mtm-text-black hover:mtm-animate-none";
 
 function NavigationBar() {
   const [toggled, setToggled] = useState(0);
+  const { isAuthenticated } = useAuth();
+  const navigate = useNavigate();
+
+  const handleLogout = async () => {
+    await logoutUser();
+    navigate("/login", { replace: true });
+  };
   return (
     <Navbar
       sticky="top"
@@ -45,28 +53,60 @@ function NavigationBar() {
       </Navbar.Toggle>
       <Navbar.Collapse id="responsive-navbar-nav">
         <Nav className="mtm-ml-auto mtm-py-10 sm:mtm-py-0">
-          <Nav.Link
-            eventKey={2}
-            className="mtm-mx-auto mtm-my-4 md:mtm-my-0"
-            as={"div"}
-          >
-            <Link to={"/login"} preventScrollReset>
-              <Button variant="warning" size="md" className={twButton}>
-                <span className="mtm-tracking-widest">Sign in</span>
-              </Button>
-            </Link>
-          </Nav.Link>
-          <Nav.Link
-            eventKey={2}
-            className="mtm-mx-auto mtm-my-4 md:mtm-my-0"
-            as={"div"}
-          >
-            <Link to={"/register"}>
-              <Button variant="warning" size="md" className={twButton}>
-                <span className="mtm-tracking-widest">Try Now!</span>
-              </Button>
-            </Link>
-          </Nav.Link>
+          {isAuthenticated ? (
+            <>
+              <Nav.Link
+                eventKey={1}
+                className="mtm-mx-auto mtm-my-4 md:mtm-my-0"
+                as={"div"}
+              >
+                <Link to={"/dashboard"} preventScrollReset>
+                  <Button variant="warning" size="md" className={twButton}>
+                    <span className="mtm-tracking-widest">Dashboard</span>
+                  </Button>
+                </Link>
+              </Nav.Link>
+              <Nav.Link
+                eventKey={2}
+                className="mtm-mx-auto mtm-my-4 md:mtm-my-0"
+                as={"div"}
+              >
+                <Button
+                  variant="warning"
+                  size="md"
+                  className={twButton}
+                  onClick={handleLogout}
+                >
+                  <span className="mtm-tracking-widest">Logout</span>
+                </Button>
+              </Nav.Link>
+            </>
+          ) : (
+            <>
+              <Nav.Link
+                eventKey={1}
+                className="mtm-mx-auto mtm-my-4 md:mtm-my-0"
+                as={"div"}
+              >
+                <Link to={"/login"} preventScrollReset>
+                  <Button variant="warning" size="md" className={twButton}>
+                    <span className="mtm-tracking-widest">Sign in</span>
+                  </Button>
+                </Link>
+              </Nav.Link>
+              <Nav.Link
+                eventKey={2}
+                className="mtm-mx-auto mtm-my-4 md:mtm-my-0"
+                as={"div"}
+              >
+                <Link to={"/register"}>
+                  <Button variant="warning" size="md" className={twButton}>
+                    <span className="mtm-tracking-widest">Try Now!</span>
+                  </Button>
+                </Link>
+              </Nav.Link>
+            </>
+          )}
         </Nav>
       </Navbar.Collapse>
     </Navbar>

--- a/frontend/src/components/ProtectedRoute.js
+++ b/frontend/src/components/ProtectedRoute.js
@@ -1,0 +1,13 @@
+import React from "react";
+import { Navigate, useLocation } from "react-router-dom";
+import useAuth from "../hooks/useAuth";
+
+export default function ProtectedRoute({ children }) {
+  const { isAuthenticated } = useAuth();
+  const location = useLocation();
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace state={{ from: location }} />;
+  }
+  return children;
+}

--- a/frontend/src/hooks/useAuth.js
+++ b/frontend/src/hooks/useAuth.js
@@ -1,0 +1,15 @@
+import { useEffect, useState } from "react";
+import { isAuthenticated, subscribeAuth } from "../service/AuthStorage";
+
+export default function useAuth() {
+  const [authed, setAuthed] = useState(isAuthenticated());
+
+  useEffect(() => {
+    const update = () => setAuthed(isAuthenticated());
+    const unsubscribe = subscribeAuth(update);
+    update();
+    return unsubscribe;
+  }, []);
+
+  return { isAuthenticated: authed };
+}

--- a/frontend/src/service/ApiService.js
+++ b/frontend/src/service/ApiService.js
@@ -1,15 +1,93 @@
 import axios from "axios";
-
-const headers = {
-  "content-type": "application/json",
-};
+import {
+  clearTokens,
+  getAccessToken,
+  getRefreshToken,
+  setTokens,
+} from "./AuthStorage";
 
 const BASE_URL = "http://localhost:8080/mtm-dev/api/v1";
 
-const TOKEN_STORAGE_KEYS = {
-  ACCESS: "mtm_access_token",
-  REFRESH: "mtm_refresh_token",
+const PUBLIC_PATHS = ["/auth/login", "/auth/refresh", "/user/register"];
+
+const apiClient = axios.create({
+  baseURL: BASE_URL,
+  headers: { "content-type": "application/json" },
+});
+
+const isPublicPath = (url = "") => PUBLIC_PATHS.some((p) => url.endsWith(p));
+
+apiClient.interceptors.request.use((config) => {
+  const token = getAccessToken();
+  if (token && !isPublicPath(config.url)) {
+    config.headers = config.headers || {};
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+let pendingRefresh = null;
+
+const refreshAccessToken = async () => {
+  const refreshToken = getRefreshToken();
+  if (!refreshToken) {
+    throw new Error("No refresh token available");
+  }
+  if (!pendingRefresh) {
+    pendingRefresh = axios
+      .post(
+        `${BASE_URL}/auth/refresh`,
+        { token: refreshToken },
+        { headers: { "content-type": "application/json" } }
+      )
+      .then((response) => {
+        const payload = response.data && response.data.data;
+        if (!payload || !payload.accessToken) {
+          throw new Error("Refresh response missing access token");
+        }
+        setTokens({
+          accessToken: payload.accessToken,
+          refreshToken: payload.refreshToken,
+        });
+        return payload.accessToken;
+      })
+      .finally(() => {
+        pendingRefresh = null;
+      });
+  }
+  return pendingRefresh;
 };
+
+apiClient.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const original = error.config;
+    const status = error.response && error.response.status;
+
+    if (
+      status === 401 &&
+      original &&
+      !original._retried &&
+      !isPublicPath(original.url) &&
+      getRefreshToken()
+    ) {
+      original._retried = true;
+      try {
+        const newAccessToken = await refreshAccessToken();
+        original.headers = original.headers || {};
+        original.headers.Authorization = `Bearer ${newAccessToken}`;
+        return apiClient(original);
+      } catch (refreshError) {
+        clearTokens();
+        if (typeof window !== "undefined") {
+          window.location.assign("/login");
+        }
+        return Promise.reject(refreshError);
+      }
+    }
+    return Promise.reject(error);
+  }
+);
 
 const toErrorPayload = (err) => {
   if (err.name === "AxiosError" && err.code === "ERR_NETWORK") {
@@ -23,30 +101,39 @@ const toErrorPayload = (err) => {
 };
 
 export const registerUser = async (data, callback) => {
-  axios
-    .post(`${BASE_URL}/user/register`, data, { headers: headers })
+  apiClient
+    .post(`/user/register`, data)
     .then((response) => callback(response.data, null))
     .catch((err) => callback(null, toErrorPayload(err)));
 };
 
 export const loginUser = async (data, callback) => {
-  axios
-    .post(`${BASE_URL}/auth/login`, data, { headers: headers })
+  apiClient
+    .post(`/auth/login`, data)
     .then((response) => {
       const payload = response.data && response.data.data;
       if (payload && payload.accessToken) {
-        localStorage.setItem(TOKEN_STORAGE_KEYS.ACCESS, payload.accessToken);
-        localStorage.setItem(TOKEN_STORAGE_KEYS.REFRESH, payload.refreshToken);
+        setTokens({
+          accessToken: payload.accessToken,
+          refreshToken: payload.refreshToken,
+        });
       }
       callback(response.data, null);
     })
     .catch((err) => callback(null, toErrorPayload(err)));
 };
 
-export const logoutUser = () => {
-  localStorage.removeItem(TOKEN_STORAGE_KEYS.ACCESS);
-  localStorage.removeItem(TOKEN_STORAGE_KEYS.REFRESH);
+export const logoutUser = async () => {
+  try {
+    if (getAccessToken()) {
+      await apiClient.post(`/auth/logout`, {});
+    }
+  } catch (e) {
+    // Server-side logout failure shouldn't keep the user signed in locally.
+  } finally {
+    clearTokens();
+  }
 };
 
-export const getStoredAccessToken = () =>
-  localStorage.getItem(TOKEN_STORAGE_KEYS.ACCESS);
+export { getAccessToken, isAuthenticated } from "./AuthStorage";
+export default apiClient;

--- a/frontend/src/service/AuthStorage.js
+++ b/frontend/src/service/AuthStorage.js
@@ -1,0 +1,58 @@
+const TOKEN_STORAGE_KEYS = {
+  ACCESS: "mtm_access_token",
+  REFRESH: "mtm_refresh_token",
+};
+
+const listeners = new Set();
+
+const notify = () => {
+  listeners.forEach((listener) => {
+    try {
+      listener();
+    } catch (e) {
+      // listener failures must not break notification
+    }
+  });
+};
+
+export const getAccessToken = () =>
+  localStorage.getItem(TOKEN_STORAGE_KEYS.ACCESS);
+
+export const getRefreshToken = () =>
+  localStorage.getItem(TOKEN_STORAGE_KEYS.REFRESH);
+
+export const isAuthenticated = () => Boolean(getAccessToken());
+
+export const setTokens = ({ accessToken, refreshToken }) => {
+  if (accessToken) {
+    localStorage.setItem(TOKEN_STORAGE_KEYS.ACCESS, accessToken);
+  }
+  if (refreshToken) {
+    localStorage.setItem(TOKEN_STORAGE_KEYS.REFRESH, refreshToken);
+  }
+  notify();
+};
+
+export const clearTokens = () => {
+  localStorage.removeItem(TOKEN_STORAGE_KEYS.ACCESS);
+  localStorage.removeItem(TOKEN_STORAGE_KEYS.REFRESH);
+  notify();
+};
+
+export const subscribeAuth = (listener) => {
+  listeners.add(listener);
+  // Cross-tab sync: storage events fire in other tabs when localStorage changes.
+  const onStorage = (event) => {
+    if (
+      event.key === TOKEN_STORAGE_KEYS.ACCESS ||
+      event.key === TOKEN_STORAGE_KEYS.REFRESH
+    ) {
+      listener();
+    }
+  };
+  window.addEventListener("storage", onStorage);
+  return () => {
+    listeners.delete(listener);
+    window.removeEventListener("storage", onStorage);
+  };
+};


### PR DESCRIPTION
… routes

Backend
-------
* RoleServiceImpl.updateRoleDetails(): replaced null stub with a real update flow — looks up the role by id, no-ops on identical names, rejects with MicroTimeManagementBadRequestException when another active role already owns the new name, otherwise persists. RoleUpdateRequestDTO now has @NotBlank on both fields.
* ActivityRecordServiceImpl.updateActivity(): now takes an ActivityUpdateRequestDTO (recordId + optional name/description/ times). Metadata-only edits mutate in place; full re-time removes the old activity and reruns the standard creation pipeline so overlap and chronological-ordering checks stay in one place. Controller now accepts the body and runs validation.
* UserServiceImpl: private finders (findById/findByUsername/ findByEmail) now throw MicroTimeManagementNotFoundException for missing users (was MicroTimeManagementUserException -> 409, wrong for not-found). The duplicate-user path still throws 409 as before.
* RefreshToken.getActiveAccessToken(): replaced toList().get(0) with findFirst().orElse(null) to avoid IOOBE when no active access token exists.
* MicroTimeManagementResourceExceptionHandler: removed System.out.println debug calls; routed through slf4j at debug.
* MtmSessionFilter: replaced blanket-403 catch with a split — MicroTimeManagementAuthenticationException returns 401 with the original message, any other exception returns 500 with a generic message. printStackTrace() removed; shared writeErrorResponse helper keeps JSON shape consistent.
* AccessTokenServiceImpl.validateAccessToken: enforces the DB record's expiresAt with SESSION_EXPIRED in addition to the existing JWT-level expiry check.
* JWT secret externalized: application-dev.yml reads \${MTM_JWT_SECRET} with a dev-only fallback; application-prod.yml requires the env var with no fallback. JwtUtils dropped the unsafe :secret default (would have failed HS512's 64-byte minimum anyway).

Frontend
--------
* service/AuthStorage.js (new): single source of truth for access/refresh tokens in localStorage. Exposes a subscriber API and listens for cross-tab `storage` events so other tabs react to login/logout.
* service/ApiService.js: refactored to a shared Axios client with
  two interceptors. Request: attaches Authorization: Bearer <token>
  for any non-public path. Response: on 401 for a retryable request, calls POST /auth/refresh, stores the new pair, and retries the original request once. Concurrent 401s share a single in-flight refresh promise. Refresh failure clears tokens and redirects to /login. Added logoutUser that calls the backend and clears local state.
* hooks/useAuth.js (new) + components/ProtectedRoute.js (new): reactive auth hook over subscribeAuth + route wrapper that redirects unauthenticated users to /login while preserving the intended destination via location.state.from.
* Pages/Dashboard.js (new): minimal placeholder so the new /dashboard route is wired end-to-end behind ProtectedRoute.
* Pages/App.js: registered the /dashboard route inside ProtectedRoute.
* Pages/Login.js: post-login navigation now goes to location.state.from when present, else /dashboard.
* components/NavigationBar.js: auth-aware nav — Sign in / Try Now when logged out, Dashboard / Logout when logged in. Logout calls the backend then navigates to /login.

Verification
------------
* mvn -q compile is clean.
* mvn -q test: 25/32 pass. The 7 failing/erroring tests are the pre-existing flaky SessionServiceImplTest cases (Mockito stubs returning null) documented in CLAUDE.md; count unchanged.
* npm run build succeeds; no new ESLint warnings in any touched file.