### PR TITLE
Activity tracking feature: end-to-end CRUD with backend tests

### DIFF
--- a/backend/api-service/src/main/java/com/microtimemanagement/apiservice/service/impl/ActivityRecordServiceImpl.java
+++ b/backend/api-service/src/main/java/com/microtimemanagement/apiservice/service/impl/ActivityRecordServiceImpl.java
@@ -193,9 +193,16 @@ public class ActivityRecordServiceImpl implements ActivityRecordService {
 
         if (retime) {
             // Remove the existing entry, then re-insert via the create pipeline so overlap
-            // validation and chronological ordering stay in one place.
+            // validation and chronological ordering stay in one place. If the record becomes
+            // empty, delete it outright — leaving an empty record around would make the
+            // create pipeline trip its "existing record + nothing inserted" guard and falsely
+            // report an overlap.
             activityRecord.getActivities().removeIf(a -> a.getId().equals(updateRequest.getRecordId()));
-            saveRecord(activityRecord);
+            if (activityRecord.getActivities().isEmpty()) {
+                activityRecordRepository.delete(activityRecord);
+            } else {
+                saveRecord(activityRecord);
+            }
 
             ActivityRecordCreationRequestDTO creationDTO = new ActivityRecordCreationRequestDTO();
             creationDTO.setRecordDate(date);

--- a/backend/api-service/src/test/java/com/microtimemanagement/apiservice/factories/ActivityTestFactory.java
+++ b/backend/api-service/src/test/java/com/microtimemanagement/apiservice/factories/ActivityTestFactory.java
@@ -1,0 +1,137 @@
+package com.microtimemanagement.apiservice.factories;
+
+import com.microtimemanagement.apiservice.dto.request.ActivityRecordCreationRequestDTO;
+import com.microtimemanagement.apiservice.dto.request.ActivityUpdateRequestDTO;
+import com.microtimemanagement.apiservice.enums.TimeMeridian;
+import com.microtimemanagement.apiservice.model.Activity;
+import com.microtimemanagement.apiservice.model.ActivityRecord;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public class ActivityTestFactory {
+
+    public static class Defaults {
+        public static final String RECORD_DATE = "2026-05-26";
+        public static final String CREATED_BY_UID = "test-user-uid";
+        public static final String ACTIVITY_NAME = "Focus block";
+        public static final String ACTIVITY_DESCRIPTION = "Deep work";
+        public static final String START_HOUR_MINUTES = "09:00:0"; // 9:00 AM (Calendar.AM = 0)
+        public static final String END_HOUR_MINUTES = "10:00:0";   // 10:00 AM
+    }
+
+    public static ActivityRecordCreationRequestDTO creationRequest() {
+        return creationRequest(
+                Defaults.RECORD_DATE,
+                Defaults.ACTIVITY_NAME,
+                Defaults.ACTIVITY_DESCRIPTION,
+                Defaults.START_HOUR_MINUTES,
+                Defaults.END_HOUR_MINUTES
+        );
+    }
+
+    public static ActivityRecordCreationRequestDTO creationRequest(
+            String recordDate,
+            String name,
+            String description,
+            String startHourMinutes,
+            String endHourMinutes
+    ) {
+        ActivityRecordCreationRequestDTO dto = new ActivityRecordCreationRequestDTO();
+        dto.setRecordDate(recordDate);
+        dto.setActivityName(name);
+        dto.setActivityDescription(description);
+        dto.setActivityStartHourMinutes(startHourMinutes);
+        dto.setActivityEndHourMinutes(endHourMinutes);
+        dto.setIsNextDaySpan(Boolean.FALSE);
+        return dto;
+    }
+
+    public static ActivityUpdateRequestDTO updateMetadataRequest(String recordId, String name, String description) {
+        return ActivityUpdateRequestDTO.builder()
+                .recordId(recordId)
+                .activityName(name)
+                .activityDescription(description)
+                .build();
+    }
+
+    public static ActivityUpdateRequestDTO updateRetimeRequest(
+            String recordId,
+            String name,
+            String description,
+            String startHourMinutes,
+            String endHourMinutes
+    ) {
+        return ActivityUpdateRequestDTO.builder()
+                .recordId(recordId)
+                .activityName(name)
+                .activityDescription(description)
+                .activityStartHourMinutes(startHourMinutes)
+                .activityEndHourMinutes(endHourMinutes)
+                .isNextDaySpan(Boolean.FALSE)
+                .build();
+    }
+
+    /**
+     * Builds an Activity entity for tests. Times are expressed as 24-hour wall clock values
+     * (startHour24, endHour24) so meridian + epoch derivations are kept in one place.
+     */
+    public static Activity activity(
+            String recordDate,
+            int startHour24,
+            int startMinutes,
+            int endHour24,
+            int endMinutes
+    ) {
+        long startEpoch = wallClockEpochMillis(recordDate, startHour24, startMinutes);
+        long endEpoch = wallClockEpochMillis(recordDate, endHour24, endMinutes);
+
+        TimeMeridian startMeridian = startHour24 < 12 ? TimeMeridian.AM : TimeMeridian.PM;
+        TimeMeridian endMeridian = endHour24 < 12 ? TimeMeridian.AM : TimeMeridian.PM;
+
+        int startHourValue = startHour24 == 0 ? 12 : (startHour24 > 12 ? startHour24 - 12 : startHour24);
+        int endHourValue = endHour24 == 0 ? 12 : (endHour24 > 12 ? endHour24 - 12 : endHour24);
+
+        return Activity.builder()
+                .id(UUID.randomUUID().toString())
+                .activityName(Defaults.ACTIVITY_NAME)
+                .activityDescription(Defaults.ACTIVITY_DESCRIPTION)
+                .activityDate(recordDate)
+                .startTimeEpoch(startEpoch)
+                .endTimeEpoch(endEpoch)
+                .startHourValue(startHourValue)
+                .startMinutesValue(startMinutes)
+                .endHourValue(endHourValue)
+                .endMinutesValue(endMinutes)
+                .startTimeMeridian(startMeridian)
+                .endTimeMeridian(endMeridian)
+                .totalDurationInEpoch(endEpoch - startEpoch)
+                .totalDurationInMinutes((endEpoch - startEpoch) / 60000L)
+                .totalDurationInHours("01Hr:00Min")
+                .build();
+    }
+
+    public static ActivityRecord recordForUser(String userId, String date, Activity... activities) {
+        List<Activity> list = new ArrayList<>(List.of(activities));
+        return ActivityRecord.builder()
+                .id(UUID.randomUUID().toString())
+                .recordDate(date)
+                .createdBy(userId)
+                .activities(list)
+                .isActive(Boolean.TRUE)
+                .build();
+    }
+
+    private static long wallClockEpochMillis(String date, int hour24, int minutes) {
+        String[] parts = date.split("-");
+        int year = Integer.parseInt(parts[0]);
+        int month = Integer.parseInt(parts[1]) - 1;
+        int day = Integer.parseInt(parts[2]);
+        return new java.util.Calendar.Builder()
+                .setDate(year, month, day)
+                .setTimeOfDay(hour24, minutes, 0)
+                .build()
+                .getTimeInMillis();
+    }
+}

--- a/backend/api-service/src/test/java/com/microtimemanagement/apiservice/service/ActivityRecordServiceImplTest.java
+++ b/backend/api-service/src/test/java/com/microtimemanagement/apiservice/service/ActivityRecordServiceImplTest.java
@@ -1,0 +1,447 @@
+package com.microtimemanagement.apiservice.service;
+
+import com.microtimemanagement.apiservice.constants.ErrorConstants;
+import com.microtimemanagement.apiservice.converter.ActivityDTOConverter;
+import com.microtimemanagement.apiservice.dto.entity.UserDTO;
+import com.microtimemanagement.apiservice.dto.request.ActivityRecordCreationRequestDTO;
+import com.microtimemanagement.apiservice.dto.request.ActivityUpdateRequestDTO;
+import com.microtimemanagement.apiservice.dto.response.ActivityRecordCreationdResponseDTO;
+import com.microtimemanagement.apiservice.dto.response.ActivityRecordResponseDTO;
+import com.microtimemanagement.apiservice.exceptions.MicroTimeManagementBadRequestException;
+import com.microtimemanagement.apiservice.exceptions.MicroTimeManagementNotFoundException;
+import com.microtimemanagement.apiservice.factories.ActivityTestFactory;
+import com.microtimemanagement.apiservice.factories.UserTestFactory;
+import com.microtimemanagement.apiservice.model.Activity;
+import com.microtimemanagement.apiservice.model.ActivityRecord;
+import com.microtimemanagement.apiservice.repository.ActivityRecordRepository;
+import com.microtimemanagement.apiservice.service.impl.ActivityRecordServiceImpl;
+import com.microtimemanagement.apiservice.service.impl.ActivityServiceImpl;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.text.ParseException;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+@DisplayName("Activity Record Service Tests")
+@ExtendWith(MockitoExtension.class)
+public class ActivityRecordServiceImplTest {
+
+    @Mock
+    private ActivityRecordRepository activityRecordRepository;
+
+    @Spy
+    private ActivityServiceImpl activityService;
+
+    @Spy
+    private ActivityDTOConverter activityConverter;
+
+    @Mock
+    private UserService userService;
+
+    @InjectMocks
+    private ActivityRecordServiceImpl activityRecordService;
+
+    private UserDTO authenticatedUser;
+
+    @BeforeEach
+    void setUpAuthenticatedPrincipal() {
+        authenticatedUser = UserTestFactory.existingAppUserDTO().build();
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(
+                        authenticatedUser.getUsername(), null, List.of()
+                )
+        );
+        Mockito.lenient()
+                .when(userService.loadUserDTOByUsername(authenticatedUser.getUsername()))
+                .thenReturn(authenticatedUser);
+    }
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    // -- processCreateUpdateRequest ---------------------------------------
+
+    @Test
+    @DisplayName("Should create a brand new activity record when none exists for the date.")
+    void shouldCreateNewActivityRecord() throws ParseException {
+        ActivityRecordCreationRequestDTO request = ActivityTestFactory.creationRequest();
+        Mockito.when(activityRecordRepository.findByRecordDate(request.getRecordDate()))
+                .thenReturn(Optional.empty());
+
+        ActivityRecordCreationdResponseDTO response = activityRecordService.processCreateUpdateRequest(request);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getActivities()).hasSize(1);
+        assertThat(response.getActivities().get(0).getActivityName())
+                .isEqualTo(ActivityTestFactory.Defaults.ACTIVITY_NAME);
+
+        ArgumentCaptor<List<ActivityRecord>> savedRecords =
+                ArgumentCaptor.forClass(List.class);
+        Mockito.verify(activityRecordRepository).saveAll(savedRecords.capture());
+        List<ActivityRecord> persisted = savedRecords.getValue();
+        assertThat(persisted).hasSize(1);
+        assertThat(persisted.get(0).getCreatedBy()).isEqualTo(authenticatedUser.getUid());
+        assertThat(persisted.get(0).getRecordDate()).isEqualTo(request.getRecordDate());
+    }
+
+    @Test
+    @DisplayName("Should append a non-overlapping activity to an existing record for the same date.")
+    void shouldAppendNonOverlappingActivityToExistingRecord() throws ParseException {
+        Activity earlierActivity = ActivityTestFactory.activity(
+                ActivityTestFactory.Defaults.RECORD_DATE, 7, 0, 8, 0
+        );
+        ActivityRecord existingRecord = ActivityTestFactory.recordForUser(
+                authenticatedUser.getUid(),
+                ActivityTestFactory.Defaults.RECORD_DATE,
+                earlierActivity
+        );
+        Mockito.when(activityRecordRepository.findByRecordDate(ActivityTestFactory.Defaults.RECORD_DATE))
+                .thenReturn(Optional.of(existingRecord));
+
+        ActivityRecordCreationRequestDTO request = ActivityTestFactory.creationRequest();
+
+        ActivityRecordCreationdResponseDTO response =
+                activityRecordService.processCreateUpdateRequest(request);
+
+        assertThat(response.getActivities()).hasSize(1);
+        assertThat(existingRecord.getActivities()).hasSize(2);
+        // Existing activity should stay first since it ends before the new one starts.
+        assertThat(existingRecord.getActivities().get(0).getId()).isEqualTo(earlierActivity.getId());
+    }
+
+    @Test
+    @DisplayName("Should reject an activity that exactly matches an existing time range.")
+    void shouldRejectDuplicateTimeRangeActivity() {
+        Activity existingActivity = ActivityTestFactory.activity(
+                ActivityTestFactory.Defaults.RECORD_DATE, 9, 0, 10, 0
+        );
+        ActivityRecord existingRecord = ActivityTestFactory.recordForUser(
+                authenticatedUser.getUid(),
+                ActivityTestFactory.Defaults.RECORD_DATE,
+                existingActivity
+        );
+        Mockito.when(activityRecordRepository.findByRecordDate(ActivityTestFactory.Defaults.RECORD_DATE))
+                .thenReturn(Optional.of(existingRecord));
+
+        ActivityRecordCreationRequestDTO request = ActivityTestFactory.creationRequest();
+
+        assertThatExceptionOfType(MicroTimeManagementBadRequestException.class)
+                .isThrownBy(() -> activityRecordService.processCreateUpdateRequest(request))
+                .withMessageContaining("Record already exists");
+    }
+
+    @Test
+    @DisplayName("Should reject an activity whose time range overlaps with an existing activity.")
+    void shouldRejectOverlappingActivity() {
+        Activity existing = ActivityTestFactory.activity(
+                ActivityTestFactory.Defaults.RECORD_DATE, 9, 0, 10, 30
+        );
+        ActivityRecord existingRecord = ActivityTestFactory.recordForUser(
+                authenticatedUser.getUid(),
+                ActivityTestFactory.Defaults.RECORD_DATE,
+                existing
+        );
+        Mockito.when(activityRecordRepository.findByRecordDate(ActivityTestFactory.Defaults.RECORD_DATE))
+                .thenReturn(Optional.of(existingRecord));
+
+        // New range 10:00 - 11:00 overlaps existing 09:00-10:30 at 10:00..10:30.
+        ActivityRecordCreationRequestDTO request = ActivityTestFactory.creationRequest(
+                ActivityTestFactory.Defaults.RECORD_DATE,
+                "Conflicting block",
+                "Should fail",
+                "10:00:0",
+                "11:00:0"
+        );
+
+        assertThatExceptionOfType(MicroTimeManagementBadRequestException.class)
+                .isThrownBy(() -> activityRecordService.processCreateUpdateRequest(request))
+                .withMessageContaining(ErrorConstants.OVERLAPPING_NEW_ACTIVITY_TIME_WITH_PREVIOUS_ACTIVITY);
+    }
+
+    @Test
+    @DisplayName("Should reject creation when the record date is not a valid yyyy-MM-dd value.")
+    void shouldRejectInvalidDateString() {
+        ActivityRecordCreationRequestDTO request = ActivityTestFactory.creationRequest(
+                "not-a-date",
+                ActivityTestFactory.Defaults.ACTIVITY_NAME,
+                ActivityTestFactory.Defaults.ACTIVITY_DESCRIPTION,
+                ActivityTestFactory.Defaults.START_HOUR_MINUTES,
+                ActivityTestFactory.Defaults.END_HOUR_MINUTES
+        );
+
+        assertThatExceptionOfType(MicroTimeManagementBadRequestException.class)
+                .isThrownBy(() -> activityRecordService.processCreateUpdateRequest(request))
+                .withMessageContaining(ErrorConstants.INVALID_DATE_VALUE);
+    }
+
+    // -- getActivitiesForDate ----------------------------------------------
+
+    @Test
+    @DisplayName("Should return the activity record for the given date scoped to the current user.")
+    void shouldReturnActivitiesForDate() {
+        Activity activity = ActivityTestFactory.activity(
+                ActivityTestFactory.Defaults.RECORD_DATE, 9, 0, 10, 0
+        );
+        ActivityRecord record = ActivityTestFactory.recordForUser(
+                authenticatedUser.getUid(),
+                ActivityTestFactory.Defaults.RECORD_DATE,
+                activity
+        );
+        Mockito.when(activityRecordRepository.findByRecordDateAndCreatedBy(
+                        ActivityTestFactory.Defaults.RECORD_DATE, authenticatedUser.getUid()))
+                .thenReturn(Optional.of(record));
+
+        ActivityRecordResponseDTO response =
+                activityRecordService.getActivitiesForDate(ActivityTestFactory.Defaults.RECORD_DATE);
+
+        assertThat(response.getRecordDate()).isEqualTo(ActivityTestFactory.Defaults.RECORD_DATE);
+        assertThat(response.getActivities()).hasSize(1);
+        assertThat(response.getActivities().get(0).getId()).isEqualTo(activity.getId());
+    }
+
+    @Test
+    @DisplayName("Should throw bad request when no activity record exists for the date.")
+    void shouldThrowBadRequestWhenNoRecordForDate() {
+        Mockito.when(activityRecordRepository.findByRecordDateAndCreatedBy(
+                        ActivityTestFactory.Defaults.RECORD_DATE, authenticatedUser.getUid()))
+                .thenReturn(Optional.empty());
+
+        assertThatExceptionOfType(MicroTimeManagementBadRequestException.class)
+                .isThrownBy(() -> activityRecordService.getActivitiesForDate(ActivityTestFactory.Defaults.RECORD_DATE))
+                .withMessageContaining("No record found for date");
+    }
+
+    // -- deleteActivity ----------------------------------------------------
+
+    @Test
+    @DisplayName("Should delete a single activity from the record and persist the update.")
+    void shouldDeleteActivityFromRecord() {
+        Activity activity = ActivityTestFactory.activity(
+                ActivityTestFactory.Defaults.RECORD_DATE, 9, 0, 10, 0
+        );
+        ActivityRecord record = ActivityTestFactory.recordForUser(
+                authenticatedUser.getUid(),
+                ActivityTestFactory.Defaults.RECORD_DATE,
+                activity
+        );
+        Mockito.when(activityRecordRepository.findByRecordDateAndCreatedBy(
+                        ActivityTestFactory.Defaults.RECORD_DATE, authenticatedUser.getUid()))
+                .thenReturn(Optional.of(record));
+        Mockito.when(activityRecordRepository.save(Mockito.any(ActivityRecord.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        ActivityRecordResponseDTO response = activityRecordService.deleteActivity(
+                ActivityTestFactory.Defaults.RECORD_DATE, activity.getId()
+        );
+
+        assertThat(response.getActivities()).isEmpty();
+        assertThat(record.getActivities()).isEmpty();
+        Mockito.verify(activityRecordRepository).save(record);
+    }
+
+    @Test
+    @DisplayName("Should throw not found when deleting from a date that has no record.")
+    void shouldThrowNotFoundWhenDeletingFromMissingRecord() {
+        Mockito.when(activityRecordRepository.findByRecordDateAndCreatedBy(
+                        ActivityTestFactory.Defaults.RECORD_DATE, authenticatedUser.getUid()))
+                .thenReturn(Optional.empty());
+
+        assertThatExceptionOfType(MicroTimeManagementNotFoundException.class)
+                .isThrownBy(() -> activityRecordService.deleteActivity(
+                        ActivityTestFactory.Defaults.RECORD_DATE, "missing-id"))
+                .withMessage(ErrorConstants.ACTIVITY_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("Should throw not found when the activity id is not present in the day's record.")
+    void shouldThrowNotFoundWhenDeletingUnknownActivityId() {
+        Activity activity = ActivityTestFactory.activity(
+                ActivityTestFactory.Defaults.RECORD_DATE, 9, 0, 10, 0
+        );
+        ActivityRecord record = ActivityTestFactory.recordForUser(
+                authenticatedUser.getUid(),
+                ActivityTestFactory.Defaults.RECORD_DATE,
+                activity
+        );
+        Mockito.when(activityRecordRepository.findByRecordDateAndCreatedBy(
+                        ActivityTestFactory.Defaults.RECORD_DATE, authenticatedUser.getUid()))
+                .thenReturn(Optional.of(record));
+
+        assertThatExceptionOfType(MicroTimeManagementNotFoundException.class)
+                .isThrownBy(() -> activityRecordService.deleteActivity(
+                        ActivityTestFactory.Defaults.RECORD_DATE, "no-such-activity"))
+                .withMessage(ErrorConstants.ACTIVITY_NOT_FOUND);
+    }
+
+    // -- updateActivity ----------------------------------------------------
+
+    @Test
+    @DisplayName("Should update activity name and description in place when no new times are provided.")
+    void shouldUpdateActivityMetadataInPlace() {
+        Activity activity = ActivityTestFactory.activity(
+                ActivityTestFactory.Defaults.RECORD_DATE, 9, 0, 10, 0
+        );
+        ActivityRecord record = ActivityTestFactory.recordForUser(
+                authenticatedUser.getUid(),
+                ActivityTestFactory.Defaults.RECORD_DATE,
+                activity
+        );
+        Mockito.when(activityRecordRepository.findByRecordDateAndCreatedBy(
+                        ActivityTestFactory.Defaults.RECORD_DATE, authenticatedUser.getUid()))
+                .thenReturn(Optional.of(record));
+        Mockito.when(activityRecordRepository.save(Mockito.any(ActivityRecord.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        ActivityUpdateRequestDTO request = ActivityTestFactory.updateMetadataRequest(
+                activity.getId(), "Renamed", "Updated description"
+        );
+
+        ActivityRecordResponseDTO response = activityRecordService.updateActivity(
+                ActivityTestFactory.Defaults.RECORD_DATE, request
+        );
+
+        assertThat(response.getActivities()).hasSize(1);
+        assertThat(activity.getActivityName()).isEqualTo("Renamed");
+        assertThat(activity.getActivityDescription()).isEqualTo("Updated description");
+        // Times unchanged
+        assertThat(activity.getStartHourValue()).isEqualTo(9);
+        assertThat(activity.getEndHourValue()).isEqualTo(10);
+    }
+
+    @Test
+    @DisplayName("Should re-time the sole activity in a record by deleting the empty record and re-creating via the pipeline.")
+    void shouldRetimeActivityViaCreationPipeline() {
+        Activity activity = ActivityTestFactory.activity(
+                ActivityTestFactory.Defaults.RECORD_DATE, 9, 0, 10, 0
+        );
+        ActivityRecord record = ActivityTestFactory.recordForUser(
+                authenticatedUser.getUid(),
+                ActivityTestFactory.Defaults.RECORD_DATE,
+                activity
+        );
+        Mockito.when(activityRecordRepository.findByRecordDateAndCreatedBy(
+                        ActivityTestFactory.Defaults.RECORD_DATE, authenticatedUser.getUid()))
+                .thenReturn(Optional.of(record));
+        // Before delete: lookup returns the (now empty) record; after delete: empty so the
+        // creation pipeline takes the "new record" path.
+        java.util.concurrent.atomic.AtomicBoolean recordDeleted = new java.util.concurrent.atomic.AtomicBoolean(false);
+        Mockito.when(activityRecordRepository.findByRecordDate(ActivityTestFactory.Defaults.RECORD_DATE))
+                .thenAnswer(invocation -> recordDeleted.get() ? Optional.empty() : Optional.of(record));
+        Mockito.doAnswer(invocation -> {
+            recordDeleted.set(true);
+            return null;
+        }).when(activityRecordRepository).delete(Mockito.any(ActivityRecord.class));
+        // Save may not be invoked on the empty-record path; keep it lenient so the test
+        // doesn't fail purely on unused-stub strictness.
+        Mockito.lenient()
+                .when(activityRecordRepository.save(Mockito.any(ActivityRecord.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        ActivityUpdateRequestDTO request = ActivityTestFactory.updateRetimeRequest(
+                activity.getId(),
+                "Renamed",
+                "Updated description",
+                "11:00:0",  // 11:00 AM
+                "11:30:0"   // 11:30 AM (stay in AM so we don't trigger meridian wrap)
+        );
+
+        assertThatNoException().isThrownBy(() -> activityRecordService.updateActivity(
+                ActivityTestFactory.Defaults.RECORD_DATE, request
+        ));
+
+        // Old empty record was deleted; the create pipeline persisted a fresh record.
+        Mockito.verify(activityRecordRepository).delete(record);
+        ArgumentCaptor<List<ActivityRecord>> savedRecords = ArgumentCaptor.forClass(List.class);
+        Mockito.verify(activityRecordRepository).saveAll(savedRecords.capture());
+        List<ActivityRecord> persisted = savedRecords.getValue();
+        assertThat(persisted).hasSize(1);
+        Activity replacement = persisted.get(0).getActivities().get(0);
+        assertThat(replacement.getId()).isNotEqualTo(activity.getId());
+        assertThat(replacement.getStartHourValue()).isEqualTo(11);
+        assertThat(replacement.getEndHourValue()).isEqualTo(11);
+        assertThat(replacement.getEndMinutesValue()).isEqualTo(30);
+        assertThat(replacement.getActivityName()).isEqualTo("Renamed");
+    }
+
+    @Test
+    @DisplayName("Should throw not found when updating an activity id that does not exist in the record.")
+    void shouldThrowNotFoundWhenUpdatingUnknownActivityId() {
+        Activity activity = ActivityTestFactory.activity(
+                ActivityTestFactory.Defaults.RECORD_DATE, 9, 0, 10, 0
+        );
+        ActivityRecord record = ActivityTestFactory.recordForUser(
+                authenticatedUser.getUid(),
+                ActivityTestFactory.Defaults.RECORD_DATE,
+                activity
+        );
+        Mockito.when(activityRecordRepository.findByRecordDateAndCreatedBy(
+                        ActivityTestFactory.Defaults.RECORD_DATE, authenticatedUser.getUid()))
+                .thenReturn(Optional.of(record));
+
+        ActivityUpdateRequestDTO request = ActivityTestFactory.updateMetadataRequest(
+                "no-such-activity", "Renamed", "Updated description"
+        );
+
+        assertThatExceptionOfType(MicroTimeManagementNotFoundException.class)
+                .isThrownBy(() -> activityRecordService.updateActivity(
+                        ActivityTestFactory.Defaults.RECORD_DATE, request))
+                .withMessage(ErrorConstants.ACTIVITY_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("Should throw bad request when a re-time would overlap a different activity in the record.")
+    void shouldRejectRetimeWhenItOverlapsOtherActivity() {
+        // Blocker occupies 11:00 AM - 11:45 AM
+        Activity blocker = ActivityTestFactory.activity(
+                ActivityTestFactory.Defaults.RECORD_DATE, 11, 0, 11, 45
+        );
+        // Target occupies 9:00 AM - 10:00 AM
+        Activity target = ActivityTestFactory.activity(
+                ActivityTestFactory.Defaults.RECORD_DATE, 9, 0, 10, 0
+        );
+        ActivityRecord record = ActivityTestFactory.recordForUser(
+                authenticatedUser.getUid(),
+                ActivityTestFactory.Defaults.RECORD_DATE,
+                target, blocker
+        );
+        Mockito.when(activityRecordRepository.findByRecordDateAndCreatedBy(
+                        ActivityTestFactory.Defaults.RECORD_DATE, authenticatedUser.getUid()))
+                .thenReturn(Optional.of(record));
+        Mockito.when(activityRecordRepository.findByRecordDate(ActivityTestFactory.Defaults.RECORD_DATE))
+                .thenAnswer(invocation -> Optional.of(record));
+        Mockito.when(activityRecordRepository.save(Mockito.any(ActivityRecord.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // Try to move target into 11:15 AM - 11:30 AM, which overlaps the blocker (11:00 - 11:45 AM).
+        ActivityUpdateRequestDTO request = ActivityTestFactory.updateRetimeRequest(
+                target.getId(),
+                "Renamed",
+                "Updated description",
+                "11:15:0",
+                "11:30:0"
+        );
+
+        assertThatExceptionOfType(MicroTimeManagementBadRequestException.class)
+                .isThrownBy(() -> activityRecordService.updateActivity(
+                        ActivityTestFactory.Defaults.RECORD_DATE, request))
+                .withMessageContaining(ErrorConstants.OVERLAPPING_NEW_ACTIVITY_TIME_WITH_PREVIOUS_ACTIVITY);
+    }
+}

--- a/frontend/src/Pages/Activity.js
+++ b/frontend/src/Pages/Activity.js
@@ -1,0 +1,353 @@
+import React, { useCallback, useEffect, useState } from "react";
+import Button from "react-bootstrap/Button";
+import {
+  createActivity,
+  deleteActivity,
+  getActivitiesForDate,
+  updateActivity,
+} from "../service/ApiService";
+
+// Backend expects time strings shaped "HH:MM:M" where the final digit is
+// 0 for AM and 1 for PM, with HH in the 1..12 range. The HTML <input type="time">
+// gives us back "HH:MM" in 24-hour form, so we translate on the way out.
+const toBackendTimeString = (hhmm24) => {
+  if (!hhmm24) return "";
+  const [hStr, mStr] = hhmm24.split(":");
+  const hour24 = parseInt(hStr, 10);
+  const minutes = parseInt(mStr, 10);
+  const meridian = hour24 < 12 ? 0 : 1;
+  let hour12 = hour24 % 12;
+  if (hour12 === 0) hour12 = 12;
+  const pad = (n) => (n < 10 ? `0${n}` : `${n}`);
+  return `${pad(hour12)}:${pad(minutes)}:${meridian}`;
+};
+
+const todayIsoDate = () => {
+  const now = new Date();
+  const pad = (n) => (n < 10 ? `0${n}` : `${n}`);
+  return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`;
+};
+
+const blankForm = () => ({
+  activityName: "",
+  activityDescription: "",
+  startTime: "",
+  endTime: "",
+});
+
+function Activity({ toastState, setToastState }) {
+  const [date, setDate] = useState(todayIsoDate());
+  const [activities, setActivities] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [form, setForm] = useState(blankForm());
+  const [editingId, setEditingId] = useState(null);
+
+  const showSuccess = (message) =>
+    setToastState({
+      display: true,
+      variant: "success",
+      messages: [message],
+      includePrefix: false,
+      includeSuffix: false,
+      suffix: "",
+    });
+
+  const showError = (messages) =>
+    setToastState({
+      display: true,
+      variant: "error",
+      messages: Array.isArray(messages) ? messages : [messages],
+      includePrefix: true,
+      includeSuffix: false,
+      suffix: "",
+    });
+
+  const errorMessageFrom = (errorPayload) => {
+    if (!errorPayload) return "Something went wrong.";
+    if (errorPayload.error && errorPayload.error.message)
+      return errorPayload.error.message;
+    if (errorPayload.message) return errorPayload.message;
+    return "Something went wrong.";
+  };
+
+  const loadActivities = useCallback(
+    (forDate) => {
+      setLoading(true);
+      getActivitiesForDate(forDate, (data, err) => {
+        setLoading(false);
+        if (err) {
+          // No record for the date is an expected "empty" state, not an error.
+          const msg = errorMessageFrom(err);
+          if (msg && msg.toLowerCase().includes("no record found")) {
+            setActivities([]);
+            return;
+          }
+          showError(msg);
+          setActivities([]);
+          return;
+        }
+        setActivities((data && data.activities) || []);
+      });
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  );
+
+  useEffect(() => {
+    loadActivities(date);
+  }, [date, loadActivities]);
+
+  const resetForm = () => {
+    setForm(blankForm());
+    setEditingId(null);
+    setCreating(false);
+  };
+
+  const handleCreate = (e) => {
+    e.preventDefault();
+    if (
+      !form.activityName ||
+      !form.startTime ||
+      !form.endTime
+    ) {
+      showError("Name, start time, and end time are required.");
+      return;
+    }
+    const payload = {
+      recordDate: date,
+      activityName: form.activityName,
+      activityDescription: form.activityDescription,
+      activityStartHourMinutes: toBackendTimeString(form.startTime),
+      activityEndHourMinutes: toBackendTimeString(form.endTime),
+    };
+    createActivity(payload, (data, err) => {
+      if (err) {
+        showError(errorMessageFrom(err));
+        return;
+      }
+      showSuccess("Activity created.");
+      resetForm();
+      loadActivities(date);
+    });
+  };
+
+  const handleUpdate = (e) => {
+    e.preventDefault();
+    if (!editingId) return;
+    const payload = {
+      recordId: editingId,
+      activityName: form.activityName || undefined,
+      activityDescription: form.activityDescription || undefined,
+      activityStartHourMinutes: form.startTime
+        ? toBackendTimeString(form.startTime)
+        : undefined,
+      activityEndHourMinutes: form.endTime
+        ? toBackendTimeString(form.endTime)
+        : undefined,
+    };
+    updateActivity(date, payload, (data, err) => {
+      if (err) {
+        showError(errorMessageFrom(err));
+        return;
+      }
+      showSuccess("Activity updated.");
+      resetForm();
+      loadActivities(date);
+    });
+  };
+
+  const handleDelete = (recordId) => {
+    if (!window.confirm("Delete this activity?")) return;
+    deleteActivity(date, recordId, (data, err) => {
+      if (err) {
+        showError(errorMessageFrom(err));
+        return;
+      }
+      showSuccess("Activity deleted.");
+      loadActivities(date);
+    });
+  };
+
+  const startEditing = (activity) => {
+    setEditingId(activity.id);
+    setCreating(false);
+    setForm({
+      activityName: activity.activityName || "",
+      activityDescription: activity.activityDescription || "",
+      // Start blank so users only submit times when they want to retime.
+      startTime: "",
+      endTime: "",
+    });
+  };
+
+  return (
+    <div className="mtm-min-h-[80vh] mtm-bg-black mtm-text-white mtm-py-12 mtm-px-4 sm:mtm-px-12">
+      <div className="mtm-max-w-4xl mtm-mx-auto">
+        <h1 className="mtm-text-3xl mtm-tracking-wider mtm-text-sky-400 mtm-mb-8">
+          Activity Tracker
+        </h1>
+
+        <div className="mtm-flex mtm-flex-col sm:mtm-flex-row mtm-items-start sm:mtm-items-center mtm-gap-4 mtm-mb-8">
+          <label className="mtm-text-white/80 mtm-tracking-wide">
+            Date:&nbsp;
+            <input
+              type="date"
+              value={date}
+              onChange={(e) => setDate(e.target.value)}
+              className="mtm-bg-black mtm-text-white mtm-border mtm-border-sky-400 mtm-rounded mtm-px-3 mtm-py-1 mtm-ml-2"
+            />
+          </label>
+          <Button
+            variant="warning"
+            onClick={() => {
+              resetForm();
+              setCreating(true);
+            }}
+          >
+            + New Activity
+          </Button>
+        </div>
+
+        {(creating || editingId) && (
+          <form
+            onSubmit={editingId ? handleUpdate : handleCreate}
+            className="mtm-bg-white/5 mtm-border mtm-border-white/20 mtm-rounded mtm-p-6 mtm-mb-8"
+          >
+            <h2 className="mtm-text-lg mtm-text-yellow-300 mtm-mb-4">
+              {editingId ? "Edit activity" : "New activity"}
+            </h2>
+            <div className="mtm-grid mtm-gap-4 sm:mtm-grid-cols-2">
+              <label className="mtm-flex mtm-flex-col">
+                <span className="mtm-text-sm mtm-text-white/70 mtm-mb-1">
+                  Name
+                </span>
+                <input
+                  type="text"
+                  value={form.activityName}
+                  onChange={(e) =>
+                    setForm((s) => ({ ...s, activityName: e.target.value }))
+                  }
+                  className="mtm-bg-black mtm-border mtm-border-white/30 mtm-rounded mtm-px-3 mtm-py-2"
+                />
+              </label>
+              <label className="mtm-flex mtm-flex-col sm:mtm-col-span-2">
+                <span className="mtm-text-sm mtm-text-white/70 mtm-mb-1">
+                  Description
+                </span>
+                <textarea
+                  rows={2}
+                  value={form.activityDescription}
+                  onChange={(e) =>
+                    setForm((s) => ({
+                      ...s,
+                      activityDescription: e.target.value,
+                    }))
+                  }
+                  className="mtm-bg-black mtm-border mtm-border-white/30 mtm-rounded mtm-px-3 mtm-py-2"
+                />
+              </label>
+              <label className="mtm-flex mtm-flex-col">
+                <span className="mtm-text-sm mtm-text-white/70 mtm-mb-1">
+                  Start time
+                  {editingId ? " (leave blank to keep)" : ""}
+                </span>
+                <input
+                  type="time"
+                  value={form.startTime}
+                  onChange={(e) =>
+                    setForm((s) => ({ ...s, startTime: e.target.value }))
+                  }
+                  className="mtm-bg-black mtm-border mtm-border-white/30 mtm-rounded mtm-px-3 mtm-py-2"
+                />
+              </label>
+              <label className="mtm-flex mtm-flex-col">
+                <span className="mtm-text-sm mtm-text-white/70 mtm-mb-1">
+                  End time
+                  {editingId ? " (leave blank to keep)" : ""}
+                </span>
+                <input
+                  type="time"
+                  value={form.endTime}
+                  onChange={(e) =>
+                    setForm((s) => ({ ...s, endTime: e.target.value }))
+                  }
+                  className="mtm-bg-black mtm-border mtm-border-white/30 mtm-rounded mtm-px-3 mtm-py-2"
+                />
+              </label>
+            </div>
+            <div className="mtm-mt-4 mtm-flex mtm-gap-2">
+              <Button type="submit" variant="warning">
+                {editingId ? "Save changes" : "Create activity"}
+              </Button>
+              <Button
+                type="button"
+                variant="outline-light"
+                onClick={resetForm}
+              >
+                Cancel
+              </Button>
+            </div>
+          </form>
+        )}
+
+        <h2 className="mtm-text-xl mtm-text-yellow-300 mtm-mb-4">
+          Activities for {date}
+        </h2>
+
+        {loading && (
+          <p className="mtm-text-white/60">Loading activities…</p>
+        )}
+
+        {!loading && activities.length === 0 && (
+          <p className="mtm-text-white/60">
+            No activities recorded for this date.
+          </p>
+        )}
+
+        <ul className="mtm-space-y-3">
+          {activities.map((activity) => (
+            <li
+              key={activity.id}
+              className="mtm-bg-white/5 mtm-border mtm-border-white/20 mtm-rounded mtm-p-4 mtm-flex mtm-flex-col sm:mtm-flex-row sm:mtm-justify-between sm:mtm-items-center mtm-gap-2"
+            >
+              <div>
+                <div className="mtm-text-lg mtm-text-white">
+                  {activity.activityName}
+                </div>
+                <div className="mtm-text-sm mtm-text-white/70">
+                  {activity.activityStartTime} → {activity.activityEndTime}
+                  &nbsp;·&nbsp;
+                  {activity.activityTotalDuration}
+                </div>
+                {activity.activityDescription && (
+                  <div className="mtm-text-sm mtm-text-white/60 mtm-mt-1">
+                    {activity.activityDescription}
+                  </div>
+                )}
+              </div>
+              <div className="mtm-flex mtm-gap-2">
+                <Button
+                  size="sm"
+                  variant="outline-warning"
+                  onClick={() => startEditing(activity)}
+                >
+                  Edit
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline-danger"
+                  onClick={() => handleDelete(activity.id)}
+                >
+                  Delete
+                </Button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+export default Activity;

--- a/frontend/src/Pages/App.js
+++ b/frontend/src/Pages/App.js
@@ -9,6 +9,7 @@ import { Route, Routes } from "react-router-dom";
 import Login from "./Login";
 import Registration from "./Registration";
 import Dashboard from "./Dashboard";
+import Activity from "./Activity";
 import ProtectedRoute from "../components/ProtectedRoute";
 import { useState } from "react";
 import Toast from "../components/Toast";
@@ -68,6 +69,17 @@ function App() {
           element={
             <ProtectedRoute>
               <Dashboard />
+            </ProtectedRoute>
+          }
+        ></Route>
+        <Route
+          path={"/activity"}
+          element={
+            <ProtectedRoute>
+              <Activity
+                toastState={toastState}
+                setToastState={setToastState}
+              />
             </ProtectedRoute>
           }
         ></Route>

--- a/frontend/src/Pages/Dashboard.js
+++ b/frontend/src/Pages/Dashboard.js
@@ -1,4 +1,6 @@
 import React from "react";
+import { Link } from "react-router-dom";
+import Button from "react-bootstrap/Button";
 
 function Dashboard() {
   return (
@@ -7,8 +9,15 @@ function Dashboard() {
         Welcome back
       </h1>
       <p className="mtm-mt-4 mtm-text-white/70">
-        Activity tracking dashboard is coming soon.
+        Jump into today's activity tracking.
       </p>
+      <div className="mtm-mt-8">
+        <Link to="/activity">
+          <Button variant="warning" size="lg">
+            <span className="mtm-tracking-widest">Track Activities</span>
+          </Button>
+        </Link>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/NavigationBar.js
+++ b/frontend/src/components/NavigationBar.js
@@ -71,6 +71,17 @@ function NavigationBar() {
                 className="mtm-mx-auto mtm-my-4 md:mtm-my-0"
                 as={"div"}
               >
+                <Link to={"/activity"} preventScrollReset>
+                  <Button variant="warning" size="md" className={twButton}>
+                    <span className="mtm-tracking-widest">Activity</span>
+                  </Button>
+                </Link>
+              </Nav.Link>
+              <Nav.Link
+                eventKey={3}
+                className="mtm-mx-auto mtm-my-4 md:mtm-my-0"
+                as={"div"}
+              >
                 <Button
                   variant="warning"
                   size="md"

--- a/frontend/src/service/ApiService.js
+++ b/frontend/src/service/ApiService.js
@@ -135,5 +135,35 @@ export const logoutUser = async () => {
   }
 };
 
+// --- Activity API ---
+
+export const createActivity = async (payload, callback) => {
+  apiClient
+    .post(`/activity`, payload)
+    .then((response) => callback(response.data, null))
+    .catch((err) => callback(null, toErrorPayload(err)));
+};
+
+export const getActivitiesForDate = async (date, callback) => {
+  apiClient
+    .get(`/activity/getAllForDate`, { params: { date } })
+    .then((response) => callback(response.data, null))
+    .catch((err) => callback(null, toErrorPayload(err)));
+};
+
+export const updateActivity = async (date, payload, callback) => {
+  apiClient
+    .put(`/activity`, payload, { params: { date } })
+    .then((response) => callback(response.data, null))
+    .catch((err) => callback(null, toErrorPayload(err)));
+};
+
+export const deleteActivity = async (date, recordId, callback) => {
+  apiClient
+    .delete(`/activity`, { params: { date, recordId } })
+    .then((response) => callback(response.data, null))
+    .catch((err) => callback(null, toErrorPayload(err)));
+};
+
 export { getAccessToken, isAuthenticated } from "./AuthStorage";
 export default apiClient;


### PR DESCRIPTION
Backend
-------
* ActivityRecordServiceImpl.updateActivity: fixed a latent bug where re-timing the only activity in a record would falsely report an overlap. The cause was that after removeIf left the record's activity list empty, processCreateUpdateRequest re-loaded the record via findByRecordDate, found a non-null record with zero activities, and tripped the "existingTimeRecord != null && !activityUpdated" guard in makeFromRecordLogRequestDTO. Fix: when removeIf empties the record, delete the record entirely before re-running the creation pipeline so it takes the "new record" branch.
* test/factories/ActivityTestFactory.java (new): builder helpers for ActivityRecordCreationRequestDTO, ActivityUpdateRequestDTO, Activity (with epoch + 12-hour + meridian derived from a single 24-hour wall clock pair), and ActivityRecord. Keeps per-test setup focused.
* test/service/ActivityRecordServiceImplTest.java (new): 14 tests covering processCreateUpdateRequest (new record / append / duplicate-time rejection / overlap rejection / invalid date), getActivitiesForDate (happy + missing record), deleteActivity (happy + missing record + unknown activity id), updateActivity (metadata-only / full retime via creation pipeline / unknown activity id / overlap rejection on retime).

Frontend
--------
* service/ApiService.js: added createActivity, getActivitiesForDate, updateActivity, deleteActivity — all going through the shared apiClient so they pick up the 401-refresh interceptor automatically.
* Pages/Activity.js: full date-scoped CRUD UI. Date picker defaults to today and re-fetches on change. Inline form for create and edit reuses the same fields; edit leaves start/end blank by default so the backend's "blank = keep" semantics keep re-timing optional. Native <input type="date"> and <input type="time"> are used to avoid touching antd configuration; times are converted from 24h HH:MM to the backend's HH:MM:M (M = 0 AM, 1 PM) at submit time via toBackendTimeString. Delete confirms before firing. Toast feedback for every success/error; missing-record on first load is treated as an "empty" state, not an error.
* Pages/App.js: registered /activity as a ProtectedRoute wired to Activity with the shared toast props.
* Pages/Dashboard.js: placeholder now CTAs into the activity tracker so the post-login flow lands somewhere useful.
* components/NavigationBar.js: added an Activity link to the authenticated nav (Dashboard | Activity | Logout).

Verification
------------
* mvn -q test -Dtest=ActivityRecordServiceImplTest: 14/14 pass.
* mvn -q test (full suite): 46 total, 8 failing — all 8 are the pre-existing flaky cases (SessionServiceImplTest x7 + ApiServiceApplicationTests's Mongo dependency x1) documented in CLAUDE.md. No new failures from this change.
* npm run build: clean. No new ESLint warnings in any touched file.