### PR TITLE
User profile feature: view/edit details + change password (TDD)

### DIFF
--- a/backend/api-service/src/main/java/com/microtimemanagement/apiservice/controller/UserController.java
+++ b/backend/api-service/src/main/java/com/microtimemanagement/apiservice/controller/UserController.java
@@ -70,7 +70,7 @@ public class UserController {
     @ResponseBody
     @SecurityRequirement(name = "MTM Auth")
     public GenericMessageResponseDTO<UserDTO> updateUser(
-            @Valid UserDetailsUpdateRequestDTO userDetailsUpdateRequestDTO,
+            @Valid @RequestBody UserDetailsUpdateRequestDTO userDetailsUpdateRequestDTO,
             BindingResult bindingResult
     ){
         ApiUtils.handleValidationErrors(bindingResult);

--- a/backend/api-service/src/main/java/com/microtimemanagement/apiservice/dto/request/PasswordChangeRequestDTO.java
+++ b/backend/api-service/src/main/java/com/microtimemanagement/apiservice/dto/request/PasswordChangeRequestDTO.java
@@ -1,13 +1,18 @@
 package com.microtimemanagement.apiservice.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Data;
 
 @Data
 public class PasswordChangeRequestDTO {
 
+    @NotBlank(message = "Old password cannot be empty.")
     private String oldPassword;
 
+    @NotBlank(message = "New password cannot be empty.")
+    @Size(min = 8, message = "New password must be at least 8 characters long.")
     private String newPassword;
 
     @JsonIgnore

--- a/backend/api-service/src/main/java/com/microtimemanagement/apiservice/service/impl/UserServiceImpl.java
+++ b/backend/api-service/src/main/java/com/microtimemanagement/apiservice/service/impl/UserServiceImpl.java
@@ -26,6 +26,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -233,15 +235,19 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public UserDTO updateUserDetails(UserDetailsUpdateRequestDTO userDetailsUpdateRequestDTO) {
+        // A user may only update their own profile. We trust the authenticated
+        // principal as the source of truth and reject any request that points at a
+        // different uid — this closes a horizontal-IDOR on /user/update.
+        String authenticatedUid = currentAuthenticatedUid();
+        if (authenticatedUid == null
+                || !authenticatedUid.equals(userDetailsUpdateRequestDTO.getUid())) {
+            throw new MicroTimeManagementUserException(ErrorConstants.CANNOT_UPDATE_UID_OF_EXISTING_USER);
+        }
+
         User currentUser = userRepository.findByUidAndIsActiveTrue(userDetailsUpdateRequestDTO.getUid());
 
         if(null == currentUser){
             throw new MicroTimeManagementBadRequestException(ErrorConstants.INVALID_USER_IDENTIFIER_VALUE);
-        }
-
-        // UIDs are used to uniquely identify the users
-        if(!currentUser.getUid().equals(userDetailsUpdateRequestDTO.getUid())){
-            throw new MicroTimeManagementUserException(ErrorConstants.CANNOT_UPDATE_UID_OF_EXISTING_USER);
         }
         // Email, username, First Name, Last Name, DOB changes are allowed
         log.info("Update user request: {}", userDetailsUpdateRequestDTO);
@@ -294,12 +300,22 @@ public class UserServiceImpl implements UserService {
     @Override
     public String changeUserPassword(PasswordChangeRequestDTO passwordChangeRequestDTO) {
         User user = findActiveUserByEmailOrUsername(passwordChangeRequestDTO.getUsername());
-        String message = ErrorConstants.SOMETHING_WENT_WRONG;
-        if(bCryptPasswordEncoder.matches(passwordChangeRequestDTO.getOldPassword(), user.getPassword())){
-            user.setPassword(bCryptPasswordEncoder.encode(passwordChangeRequestDTO.getNewPassword()));
-            message = ResponseMessages.PASSWORD_CHANGED_SUCCESSFULLY;
+        if(!bCryptPasswordEncoder.matches(passwordChangeRequestDTO.getOldPassword(), user.getPassword())){
+            throw new MicroTimeManagementBadRequestException(ErrorConstants.INVALID_PASSWORD_VALUE);
         }
-        return message;
+        user.setPassword(bCryptPasswordEncoder.encode(passwordChangeRequestDTO.getNewPassword()));
+        userRepository.save(user);
+        return ResponseMessages.PASSWORD_CHANGED_SUCCESSFULLY;
+    }
+
+    private String currentAuthenticatedUid() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null) return null;
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof User user) {
+            return user.getUid();
+        }
+        return null;
     }
 
     @Override

--- a/backend/api-service/src/test/java/com/microtimemanagement/apiservice/service/UserServiceImplTest.java
+++ b/backend/api-service/src/test/java/com/microtimemanagement/apiservice/service/UserServiceImplTest.java
@@ -1,22 +1,30 @@
 package com.microtimemanagement.apiservice.service;
 
+import com.microtimemanagement.apiservice.constants.ResponseMessages;
 import com.microtimemanagement.apiservice.converter.UserDTOConverter;
 import com.microtimemanagement.apiservice.dto.entity.UserDTO;
 import com.microtimemanagement.apiservice.dto.request.NewUserRequestDTO;
+import com.microtimemanagement.apiservice.dto.request.PasswordChangeRequestDTO;
+import com.microtimemanagement.apiservice.dto.request.UserDetailsUpdateRequestDTO;
 import com.microtimemanagement.apiservice.dto.response.NewUserResponseDTO;
+import com.microtimemanagement.apiservice.exceptions.MicroTimeManagementBadRequestException;
 import com.microtimemanagement.apiservice.exceptions.MicroTimeManagementUserException;
 import com.microtimemanagement.apiservice.factories.RoleTestFactory;
 import com.microtimemanagement.apiservice.factories.UserTestFactory;
 import com.microtimemanagement.apiservice.model.User;
 import com.microtimemanagement.apiservice.repository.UserRepository;
 import com.microtimemanagement.apiservice.service.impl.UserServiceImpl;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -206,5 +214,132 @@ public class UserServiceImplTest {
         assertThat(userDTO.getUid()).isEqualTo(authenticatedUser.getUid());
     }
 
+    // ---- updateUserDetails ----
 
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private User installAuthenticatedPrincipal() {
+        User principal = UserTestFactory.existingAppUserEntity()
+                .id(UUID.randomUUID().toString().replaceAll("-", ""))
+                .build();
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(
+                        principal, null, List.of()
+                )
+        );
+        return principal;
+    }
+
+    @Test
+    @DisplayName("updateUserDetails should mutate the authenticated user's editable fields and persist.")
+    void shouldUpdateAuthenticatedUserDetails() {
+        User principal = installAuthenticatedPrincipal();
+        Mockito.when(userRepository.findByUidAndIsActiveTrue(principal.getUid())).thenReturn(principal);
+        Mockito.when(userRepository.save(Mockito.any(User.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        UserDetailsUpdateRequestDTO update = UserDetailsUpdateRequestDTO.builder()
+                .uid(principal.getUid())
+                .username(principal.getUsername())
+                .email("renamed@example.com")
+                .firstName("Renamed")
+                .lastName("Person")
+                .dateOfBirth(principal.getDateOfBirth())
+                .build();
+
+        UserDTO result = userService.updateUserDetails(update);
+
+        assertThat(result.getEmail()).isEqualTo("renamed@example.com");
+        assertThat(result.getFirstName()).isEqualTo("Renamed");
+        assertThat(result.getLastName()).isEqualTo("Person");
+        Mockito.verify(userRepository).save(principal);
+    }
+
+    @Test
+    @DisplayName("updateUserDetails should reject when the request targets a uid other than the authenticated user.")
+    void shouldRejectUpdateForOtherUser() {
+        User principal = installAuthenticatedPrincipal();
+
+        UserDetailsUpdateRequestDTO update = UserDetailsUpdateRequestDTO.builder()
+                .uid("some-other-uid")
+                .username(principal.getUsername())
+                .email(principal.getEmail())
+                .firstName(principal.getFirstName())
+                .lastName(principal.getLastName())
+                .dateOfBirth(principal.getDateOfBirth())
+                .build();
+
+        assertThatExceptionOfType(MicroTimeManagementUserException.class)
+                .isThrownBy(() -> userService.updateUserDetails(update));
+        Mockito.verify(userRepository, Mockito.never()).save(Mockito.any(User.class));
+    }
+
+    @Test
+    @DisplayName("updateUserDetails should throw bad request when the user lookup returns nothing.")
+    void shouldThrowBadRequestWhenUserMissing() {
+        User principal = installAuthenticatedPrincipal();
+        Mockito.when(userRepository.findByUidAndIsActiveTrue(principal.getUid())).thenReturn(null);
+
+        UserDetailsUpdateRequestDTO update = UserDetailsUpdateRequestDTO.builder()
+                .uid(principal.getUid())
+                .username(principal.getUsername())
+                .email(principal.getEmail())
+                .firstName(principal.getFirstName())
+                .lastName(principal.getLastName())
+                .dateOfBirth(principal.getDateOfBirth())
+                .build();
+
+        assertThatExceptionOfType(MicroTimeManagementBadRequestException.class)
+                .isThrownBy(() -> userService.updateUserDetails(update));
+    }
+
+    // ---- changeUserPassword ----
+
+    @Test
+    @DisplayName("changeUserPassword should rehash the password and return success when the old password matches.")
+    void shouldChangePasswordWhenOldMatches() {
+        User principal = UserTestFactory.existingAppUserEntity()
+                .id(UUID.randomUUID().toString().replaceAll("-", ""))
+                .build();
+        Mockito.when(userRepository.findByEmailOrUsernameAndIsActiveTrue(principal.getUsername(), principal.getUsername()))
+                .thenReturn(Optional.of(principal));
+        Mockito.when(roleService.getRoleNamesForIds(Mockito.anySet()))
+                .thenReturn(UserTestFactory.MtmAppUserAttributes.DEFAULT_USER_ROLE_NAMES);
+        Mockito.when(bCryptPasswordEncoder.matches("oldPass", principal.getPassword())).thenReturn(true);
+        Mockito.when(bCryptPasswordEncoder.encode("newPass")).thenReturn("encoded-new");
+
+        PasswordChangeRequestDTO request = new PasswordChangeRequestDTO();
+        request.setUsername(principal.getUsername());
+        request.setOldPassword("oldPass");
+        request.setNewPassword("newPass");
+
+        String message = userService.changeUserPassword(request);
+
+        assertThat(message).isEqualTo(ResponseMessages.PASSWORD_CHANGED_SUCCESSFULLY);
+        assertThat(principal.getPassword()).isEqualTo("encoded-new");
+    }
+
+    @Test
+    @DisplayName("changeUserPassword should throw bad request when the old password does not match.")
+    void shouldThrowWhenOldPasswordWrong() {
+        User principal = UserTestFactory.existingAppUserEntity()
+                .id(UUID.randomUUID().toString().replaceAll("-", ""))
+                .build();
+        Mockito.when(userRepository.findByEmailOrUsernameAndIsActiveTrue(principal.getUsername(), principal.getUsername()))
+                .thenReturn(Optional.of(principal));
+        Mockito.when(roleService.getRoleNamesForIds(Mockito.anySet()))
+                .thenReturn(UserTestFactory.MtmAppUserAttributes.DEFAULT_USER_ROLE_NAMES);
+        Mockito.when(bCryptPasswordEncoder.matches("wrong", principal.getPassword())).thenReturn(false);
+
+        PasswordChangeRequestDTO request = new PasswordChangeRequestDTO();
+        request.setUsername(principal.getUsername());
+        request.setOldPassword("wrong");
+        request.setNewPassword("newPass");
+
+        assertThatExceptionOfType(MicroTimeManagementBadRequestException.class)
+                .isThrownBy(() -> userService.changeUserPassword(request));
+    }
 }

--- a/frontend/src/Pages/App.js
+++ b/frontend/src/Pages/App.js
@@ -10,6 +10,7 @@ import Login from "./Login";
 import Registration from "./Registration";
 import Dashboard from "./Dashboard";
 import Activity from "./Activity";
+import Profile from "./Profile";
 import ProtectedRoute from "../components/ProtectedRoute";
 import { useState } from "react";
 import Toast from "../components/Toast";
@@ -77,6 +78,17 @@ function App() {
           element={
             <ProtectedRoute>
               <Activity
+                toastState={toastState}
+                setToastState={setToastState}
+              />
+            </ProtectedRoute>
+          }
+        ></Route>
+        <Route
+          path={"/profile"}
+          element={
+            <ProtectedRoute>
+              <Profile
                 toastState={toastState}
                 setToastState={setToastState}
               />

--- a/frontend/src/Pages/Profile.js
+++ b/frontend/src/Pages/Profile.js
@@ -1,0 +1,307 @@
+import React, { useEffect, useState } from "react";
+import Button from "react-bootstrap/Button";
+import {
+  changeUserPassword,
+  getUserProfile,
+  updateUserDetails,
+} from "../service/ApiService";
+
+const blankProfile = () => ({
+  uid: "",
+  username: "",
+  email: "",
+  firstName: "",
+  lastName: "",
+  dateOfBirth: "",
+});
+
+const errorMessageFrom = (errorPayload) => {
+  if (!errorPayload) return "Something went wrong.";
+  if (errorPayload.error && errorPayload.error.message)
+    return errorPayload.error.message;
+  if (errorPayload.message) return errorPayload.message;
+  return "Something went wrong.";
+};
+
+function Profile({ toastState, setToastState }) {
+  const [profile, setProfile] = useState(blankProfile());
+  const [loading, setLoading] = useState(true);
+  const [savingProfile, setSavingProfile] = useState(false);
+  const [savingPassword, setSavingPassword] = useState(false);
+  const [passwordForm, setPasswordForm] = useState({
+    oldPassword: "",
+    newPassword: "",
+    confirmPassword: "",
+  });
+
+  const showSuccess = (message) =>
+    setToastState({
+      display: true,
+      variant: "success",
+      messages: [message],
+      includePrefix: false,
+      includeSuffix: false,
+      suffix: "",
+    });
+
+  const showError = (messages) =>
+    setToastState({
+      display: true,
+      variant: "error",
+      messages: Array.isArray(messages) ? messages : [messages],
+      includePrefix: true,
+      includeSuffix: false,
+      suffix: "",
+    });
+
+  useEffect(() => {
+    getUserProfile((data, err) => {
+      setLoading(false);
+      if (err) {
+        showError(errorMessageFrom(err));
+        return;
+      }
+      const payload = (data && data.data) || data;
+      if (payload) {
+        setProfile({
+          uid: payload.uid || "",
+          username: payload.username || "",
+          email: payload.email || "",
+          firstName: payload.firstName || "",
+          lastName: payload.lastName || "",
+          dateOfBirth: payload.dateOfBirth || "",
+        });
+      }
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleProfileSubmit = (e) => {
+    e.preventDefault();
+    if (
+      !profile.uid ||
+      !profile.username ||
+      !profile.email ||
+      !profile.firstName ||
+      !profile.dateOfBirth
+    ) {
+      showError("Username, email, first name, and date of birth are required.");
+      return;
+    }
+    setSavingProfile(true);
+    updateUserDetails(profile, (data, err) => {
+      setSavingProfile(false);
+      if (err) {
+        showError(errorMessageFrom(err));
+        return;
+      }
+      showSuccess("Profile updated.");
+    });
+  };
+
+  const handlePasswordSubmit = (e) => {
+    e.preventDefault();
+    if (
+      !passwordForm.oldPassword ||
+      !passwordForm.newPassword ||
+      !passwordForm.confirmPassword
+    ) {
+      showError("Please fill all password fields.");
+      return;
+    }
+    if (passwordForm.newPassword !== passwordForm.confirmPassword) {
+      showError("New password and confirmation do not match.");
+      return;
+    }
+    if (passwordForm.newPassword.length < 8) {
+      showError("New password must be at least 8 characters long.");
+      return;
+    }
+    setSavingPassword(true);
+    changeUserPassword(
+      {
+        oldPassword: passwordForm.oldPassword,
+        newPassword: passwordForm.newPassword,
+      },
+      (data, err) => {
+        setSavingPassword(false);
+        if (err) {
+          showError(errorMessageFrom(err));
+          return;
+        }
+        setPasswordForm({
+          oldPassword: "",
+          newPassword: "",
+          confirmPassword: "",
+        });
+        showSuccess("Password updated.");
+      }
+    );
+  };
+
+  if (loading) {
+    return (
+      <div className="mtm-min-h-[60vh] mtm-bg-black mtm-text-white mtm-py-20 mtm-text-center">
+        Loading profile…
+      </div>
+    );
+  }
+
+  return (
+    <div className="mtm-min-h-[80vh] mtm-bg-black mtm-text-white mtm-py-12 mtm-px-4 sm:mtm-px-12">
+      <div className="mtm-max-w-3xl mtm-mx-auto">
+        <h1 className="mtm-text-3xl mtm-tracking-wider mtm-text-sky-400 mtm-mb-8">
+          My Profile
+        </h1>
+
+        <form
+          onSubmit={handleProfileSubmit}
+          className="mtm-bg-white/5 mtm-border mtm-border-white/20 mtm-rounded mtm-p-6 mtm-mb-8"
+        >
+          <h2 className="mtm-text-lg mtm-text-yellow-300 mtm-mb-4">
+            Account details
+          </h2>
+          <div className="mtm-grid mtm-gap-4 sm:mtm-grid-cols-2">
+            <label className="mtm-flex mtm-flex-col">
+              <span className="mtm-text-sm mtm-text-white/70 mtm-mb-1">
+                Username
+              </span>
+              <input
+                type="text"
+                value={profile.username}
+                onChange={(e) =>
+                  setProfile((p) => ({ ...p, username: e.target.value }))
+                }
+                className="mtm-bg-black mtm-border mtm-border-white/30 mtm-rounded mtm-px-3 mtm-py-2"
+              />
+            </label>
+            <label className="mtm-flex mtm-flex-col">
+              <span className="mtm-text-sm mtm-text-white/70 mtm-mb-1">
+                Email
+              </span>
+              <input
+                type="email"
+                value={profile.email}
+                onChange={(e) =>
+                  setProfile((p) => ({ ...p, email: e.target.value }))
+                }
+                className="mtm-bg-black mtm-border mtm-border-white/30 mtm-rounded mtm-px-3 mtm-py-2"
+              />
+            </label>
+            <label className="mtm-flex mtm-flex-col">
+              <span className="mtm-text-sm mtm-text-white/70 mtm-mb-1">
+                First name
+              </span>
+              <input
+                type="text"
+                value={profile.firstName}
+                onChange={(e) =>
+                  setProfile((p) => ({ ...p, firstName: e.target.value }))
+                }
+                className="mtm-bg-black mtm-border mtm-border-white/30 mtm-rounded mtm-px-3 mtm-py-2"
+              />
+            </label>
+            <label className="mtm-flex mtm-flex-col">
+              <span className="mtm-text-sm mtm-text-white/70 mtm-mb-1">
+                Last name
+              </span>
+              <input
+                type="text"
+                value={profile.lastName}
+                onChange={(e) =>
+                  setProfile((p) => ({ ...p, lastName: e.target.value }))
+                }
+                className="mtm-bg-black mtm-border mtm-border-white/30 mtm-rounded mtm-px-3 mtm-py-2"
+              />
+            </label>
+            <label className="mtm-flex mtm-flex-col">
+              <span className="mtm-text-sm mtm-text-white/70 mtm-mb-1">
+                Date of birth
+              </span>
+              <input
+                type="text"
+                placeholder="DD-MM-YYYY"
+                value={profile.dateOfBirth}
+                onChange={(e) =>
+                  setProfile((p) => ({ ...p, dateOfBirth: e.target.value }))
+                }
+                className="mtm-bg-black mtm-border mtm-border-white/30 mtm-rounded mtm-px-3 mtm-py-2"
+              />
+            </label>
+          </div>
+          <div className="mtm-mt-4">
+            <Button type="submit" variant="warning" disabled={savingProfile}>
+              {savingProfile ? "Saving…" : "Save changes"}
+            </Button>
+          </div>
+        </form>
+
+        <form
+          onSubmit={handlePasswordSubmit}
+          className="mtm-bg-white/5 mtm-border mtm-border-white/20 mtm-rounded mtm-p-6"
+        >
+          <h2 className="mtm-text-lg mtm-text-yellow-300 mtm-mb-4">
+            Change password
+          </h2>
+          <div className="mtm-grid mtm-gap-4 sm:mtm-grid-cols-3">
+            <label className="mtm-flex mtm-flex-col">
+              <span className="mtm-text-sm mtm-text-white/70 mtm-mb-1">
+                Current password
+              </span>
+              <input
+                type="password"
+                value={passwordForm.oldPassword}
+                onChange={(e) =>
+                  setPasswordForm((p) => ({
+                    ...p,
+                    oldPassword: e.target.value,
+                  }))
+                }
+                className="mtm-bg-black mtm-border mtm-border-white/30 mtm-rounded mtm-px-3 mtm-py-2"
+              />
+            </label>
+            <label className="mtm-flex mtm-flex-col">
+              <span className="mtm-text-sm mtm-text-white/70 mtm-mb-1">
+                New password
+              </span>
+              <input
+                type="password"
+                value={passwordForm.newPassword}
+                onChange={(e) =>
+                  setPasswordForm((p) => ({
+                    ...p,
+                    newPassword: e.target.value,
+                  }))
+                }
+                className="mtm-bg-black mtm-border mtm-border-white/30 mtm-rounded mtm-px-3 mtm-py-2"
+              />
+            </label>
+            <label className="mtm-flex mtm-flex-col">
+              <span className="mtm-text-sm mtm-text-white/70 mtm-mb-1">
+                Confirm new password
+              </span>
+              <input
+                type="password"
+                value={passwordForm.confirmPassword}
+                onChange={(e) =>
+                  setPasswordForm((p) => ({
+                    ...p,
+                    confirmPassword: e.target.value,
+                  }))
+                }
+                className="mtm-bg-black mtm-border mtm-border-white/30 mtm-rounded mtm-px-3 mtm-py-2"
+              />
+            </label>
+          </div>
+          <div className="mtm-mt-4">
+            <Button type="submit" variant="warning" disabled={savingPassword}>
+              {savingPassword ? "Updating…" : "Update password"}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default Profile;

--- a/frontend/src/components/NavigationBar.js
+++ b/frontend/src/components/NavigationBar.js
@@ -82,6 +82,17 @@ function NavigationBar() {
                 className="mtm-mx-auto mtm-my-4 md:mtm-my-0"
                 as={"div"}
               >
+                <Link to={"/profile"} preventScrollReset>
+                  <Button variant="warning" size="md" className={twButton}>
+                    <span className="mtm-tracking-widest">Profile</span>
+                  </Button>
+                </Link>
+              </Nav.Link>
+              <Nav.Link
+                eventKey={4}
+                className="mtm-mx-auto mtm-my-4 md:mtm-my-0"
+                as={"div"}
+              >
                 <Button
                   variant="warning"
                   size="md"

--- a/frontend/src/service/ApiService.js
+++ b/frontend/src/service/ApiService.js
@@ -165,5 +165,28 @@ export const deleteActivity = async (date, recordId, callback) => {
     .catch((err) => callback(null, toErrorPayload(err)));
 };
 
+// --- User profile API ---
+
+export const getUserProfile = async (callback) => {
+  apiClient
+    .get(`/user/profile`)
+    .then((response) => callback(response.data, null))
+    .catch((err) => callback(null, toErrorPayload(err)));
+};
+
+export const updateUserDetails = async (payload, callback) => {
+  apiClient
+    .put(`/user/update`, payload)
+    .then((response) => callback(response.data, null))
+    .catch((err) => callback(null, toErrorPayload(err)));
+};
+
+export const changeUserPassword = async (payload, callback) => {
+  apiClient
+    .post(`/user/resetPassword`, payload)
+    .then((response) => callback(response.data, null))
+    .catch((err) => callback(null, toErrorPayload(err)));
+};
+
 export { getAccessToken, isAuthenticated } from "./AuthStorage";
 export default apiClient;


### PR DESCRIPTION
Backend
-------
TDD step 1: added 5 failing tests against the desired behaviour (update happy path, cross-uid rejection, missing user, password change happy path, wrong-old-password rejection).

TDD step 2: closed the gaps:

* UserServiceImpl.updateUserDetails — horizontal-IDOR closed. The service now reads the authenticated principal's uid from SecurityContextHolder and rejects any request whose body uid doesn't match the principal (MicroTimeManagementUserException -> 409). The previous "currentUser.getUid().equals(uid)" check was dead — currentUser had just been fetched by that uid — and is removed.
* UserServiceImpl.changeUserPassword — now throws MicroTimeManagementBadRequestException (400) when the supplied old password doesn't match. Previously it silently returned the SOMETHING_WENT_WRONG string with HTTP 200, leaving the client unable to detect failure. Also: the rehashed password is now persisted via userRepository.save (it was being set in memory only).
* PasswordChangeRequestDTO — added @NotBlank on oldPassword / newPassword and @Size(min=8) on newPassword.
* UserController.updateUser — added @RequestBody. Was implicitly binding from query parameters because the annotation was missing.

Frontend
--------
* service/ApiService.js — added getUserProfile, updateUserDetails, changeUserPassword wrappers around the shared apiClient (so they pick up the 401-refresh interceptor automatically).
* Pages/Profile.js (new) — protected page with two sections: account details (username, email, first/last name, DOB) and change password. Loads via GET /user/profile on mount; edits via PUT /user/update; password change via POST /user/resetPassword. Client-side checks: new password == confirm; new password ≥ 8 chars. Toast feedback for every success/error. DOB is a text input matching the backend's current "DD-MM-YYYY" string format — flagged in CLAUDE.md as a future swap once dates migrate to LocalDate.
* Pages/App.js — registered /profile as a ProtectedRoute.
* components/NavigationBar.js — added Profile to the authenticated nav (Dashboard | Activity | Profile | Logout).

Verification
------------
* mvn -q test -Dtest=UserServiceImplTest: 13/13 pass (5 new + 8 existing).
* mvn -q test (full suite): 51 total, 8 failing — same 8 pre-existing flaky cases as before (SessionServiceImplTest x7 + ApiServiceApplicationTests Mongo dependency x1). No new failures.
* npm run build: clean. No new ESLint warnings.