### PR TITLE
Admin role panel: role CRUD UI gated by ROLE_MTM_ADMIN_OPS (TDD)

### DIFF
--- a/backend/api-service/src/main/java/com/microtimemanagement/apiservice/dto/entity/UserDTO.java
+++ b/backend/api-service/src/main/java/com/microtimemanagement/apiservice/dto/entity/UserDTO.java
@@ -39,7 +39,6 @@ public class UserDTO {
 
     private Date lastUpdatedAt;
 
-    @JsonIgnore
     private Set<String> roles;
 
     @JsonIgnore

--- a/backend/api-service/src/test/java/com/microtimemanagement/apiservice/service/RoleServiceImplTest.java
+++ b/backend/api-service/src/test/java/com/microtimemanagement/apiservice/service/RoleServiceImplTest.java
@@ -1,0 +1,193 @@
+package com.microtimemanagement.apiservice.service;
+
+import com.microtimemanagement.apiservice.constants.ErrorConstants;
+import com.microtimemanagement.apiservice.constants.ResponseMessages;
+import com.microtimemanagement.apiservice.converter.RoleConverter;
+import com.microtimemanagement.apiservice.dto.entity.RoleDTO;
+import com.microtimemanagement.apiservice.dto.request.NewRoleRequestDTO;
+import com.microtimemanagement.apiservice.dto.request.RoleUpdateRequestDTO;
+import com.microtimemanagement.apiservice.exceptions.MicroTimeManagementBadRequestException;
+import com.microtimemanagement.apiservice.exceptions.MicroTimeManagementNotFoundException;
+import com.microtimemanagement.apiservice.model.Role;
+import com.microtimemanagement.apiservice.repository.RoleRepository;
+import com.microtimemanagement.apiservice.service.impl.RoleServiceImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+@DisplayName("Role Service Tests")
+@ExtendWith(MockitoExtension.class)
+public class RoleServiceImplTest {
+
+    @Mock
+    private RoleRepository roleRepository;
+
+    @Spy
+    private RoleConverter roleConverter;
+
+    @InjectMocks
+    private RoleServiceImpl roleService;
+
+    // -- createNewRole -----------------------------------------------------
+
+    @Test
+    @DisplayName("createNewRole should persist a role with the supplied name and return its DTO.")
+    void shouldCreateNewRole() {
+        NewRoleRequestDTO request = NewRoleRequestDTO.builder().roleName("MTM_NEW_ROLE").build();
+        Mockito.when(roleRepository.save(Mockito.any(Role.class)))
+                .thenAnswer(invocation -> {
+                    Role role = invocation.getArgument(0);
+                    role.setId("generated-id");
+                    return role;
+                });
+
+        RoleDTO created = roleService.createNewRole(request);
+
+        ArgumentCaptor<Role> saved = ArgumentCaptor.forClass(Role.class);
+        Mockito.verify(roleRepository).save(saved.capture());
+        assertThat(saved.getValue().getName()).isEqualTo("MTM_NEW_ROLE");
+        assertThat(created.getName()).isEqualTo("MTM_NEW_ROLE");
+        assertThat(created.getId()).isEqualTo("generated-id");
+    }
+
+    // -- getRoleById -------------------------------------------------------
+
+    @Test
+    @DisplayName("getRoleById should return the role DTO for an existing id.")
+    void shouldGetRoleById() {
+        Role role = Role.builder().id("role-id").name("MTM_USER_OPS").build();
+        role.setIsActive(Boolean.TRUE);
+        Mockito.when(roleRepository.findByIdAndIsActiveTrue("role-id")).thenReturn(role);
+
+        RoleDTO dto = roleService.getRoleById("role-id");
+
+        assertThat(dto.getId()).isEqualTo("role-id");
+        assertThat(dto.getName()).isEqualTo("MTM_USER_OPS");
+    }
+
+    // -- getAllRoles -------------------------------------------------------
+
+    @Test
+    @DisplayName("getAllRoles should return a list mapped from a Page of roles.")
+    void shouldListAllRoles() {
+        Role first = Role.builder().id("1").name("MTM_ROLE_CRUD").build();
+        Role second = Role.builder().id("2").name("MTM_USER_OPS").build();
+        first.setIsActive(Boolean.TRUE);
+        second.setIsActive(Boolean.TRUE);
+        Page<Role> page = new PageImpl<>(List.of(first, second));
+        Mockito.when(roleRepository.findAll(Mockito.any(Pageable.class))).thenReturn(page);
+
+        List<RoleDTO> roles = roleService.getAllRoles(0, 10);
+
+        assertThat(roles).hasSize(2);
+        assertThat(roles).extracting(RoleDTO::getName)
+                .containsExactlyInAnyOrder("MTM_ROLE_CRUD", "MTM_USER_OPS");
+    }
+
+    // -- deleteRole --------------------------------------------------------
+
+    @Test
+    @DisplayName("deleteRole should soft-delete the role by setting isActive to false.")
+    void shouldSoftDeleteRole() {
+        Role role = Role.builder().id("role-id").name("MTM_USER_OPS").build();
+        role.setIsActive(Boolean.TRUE);
+        Mockito.when(roleRepository.findByIdAndIsActiveTrue("role-id")).thenReturn(role);
+        Mockito.when(roleRepository.save(role)).thenReturn(role);
+
+        String message = roleService.deleteRole("role-id");
+
+        assertThat(message).isEqualTo(ResponseMessages.SUCCESS);
+        assertThat(role.getIsActive()).isFalse();
+        Mockito.verify(roleRepository).save(role);
+    }
+
+    // -- updateRoleDetails -------------------------------------------------
+
+    @Test
+    @DisplayName("updateRoleDetails should rename the role when the new name is free and persist.")
+    void shouldRenameRole() {
+        Role role = Role.builder().id("role-id").name("OLD_NAME").build();
+        role.setIsActive(Boolean.TRUE);
+        Mockito.when(roleRepository.findByIdAndIsActiveTrue("role-id")).thenReturn(role);
+        Mockito.when(roleRepository.findByNameAndIsActiveTrue("NEW_NAME")).thenReturn(null);
+        Mockito.when(roleRepository.save(role)).thenReturn(role);
+
+        RoleUpdateRequestDTO request = RoleUpdateRequestDTO.builder()
+                .roleId("role-id")
+                .roleName("NEW_NAME")
+                .build();
+
+        RoleDTO result = roleService.updateRoleDetails(request);
+
+        assertThat(result.getName()).isEqualTo("NEW_NAME");
+        assertThat(role.getName()).isEqualTo("NEW_NAME");
+    }
+
+    @Test
+    @DisplayName("updateRoleDetails should no-op when the name has not changed.")
+    void shouldNoOpWhenNameUnchanged() {
+        Role role = Role.builder().id("role-id").name("MTM_USER_OPS").build();
+        role.setIsActive(Boolean.TRUE);
+        Mockito.when(roleRepository.findByIdAndIsActiveTrue("role-id")).thenReturn(role);
+
+        RoleUpdateRequestDTO request = RoleUpdateRequestDTO.builder()
+                .roleId("role-id")
+                .roleName("MTM_USER_OPS")
+                .build();
+
+        RoleDTO result = roleService.updateRoleDetails(request);
+
+        assertThat(result.getName()).isEqualTo("MTM_USER_OPS");
+        Mockito.verify(roleRepository, Mockito.never()).save(Mockito.any(Role.class));
+    }
+
+    @Test
+    @DisplayName("updateRoleDetails should throw bad request when another active role already owns the new name.")
+    void shouldRejectWhenNameConflicts() {
+        Role role = Role.builder().id("role-id").name("OLD_NAME").build();
+        role.setIsActive(Boolean.TRUE);
+        Role conflicting = Role.builder().id("other-id").name("NEW_NAME").build();
+        conflicting.setIsActive(Boolean.TRUE);
+        Mockito.when(roleRepository.findByIdAndIsActiveTrue("role-id")).thenReturn(role);
+        Mockito.when(roleRepository.findByNameAndIsActiveTrue("NEW_NAME")).thenReturn(conflicting);
+
+        RoleUpdateRequestDTO request = RoleUpdateRequestDTO.builder()
+                .roleId("role-id")
+                .roleName("NEW_NAME")
+                .build();
+
+        assertThatExceptionOfType(MicroTimeManagementBadRequestException.class)
+                .isThrownBy(() -> roleService.updateRoleDetails(request))
+                .withMessage(ErrorConstants.ACTIVE_ROLE_ALREADY_EXISTS_ERROR);
+        Mockito.verify(roleRepository, Mockito.never()).save(Mockito.any(Role.class));
+    }
+
+    @Test
+    @DisplayName("updateRoleDetails should throw not found when the id does not match any active role.")
+    void shouldThrowNotFoundOnUnknownId() {
+        Mockito.when(roleRepository.findByIdAndIsActiveTrue("missing-id")).thenReturn(null);
+
+        RoleUpdateRequestDTO request = RoleUpdateRequestDTO.builder()
+                .roleId("missing-id")
+                .roleName("ANY_NAME")
+                .build();
+
+        assertThatExceptionOfType(MicroTimeManagementNotFoundException.class)
+                .isThrownBy(() -> roleService.updateRoleDetails(request))
+                .withMessage(ErrorConstants.ROLE_NOT_FOUND_ERROR);
+    }
+}

--- a/frontend/src/Pages/Admin.js
+++ b/frontend/src/Pages/Admin.js
@@ -1,0 +1,220 @@
+import React, { useCallback, useEffect, useState } from "react";
+import Button from "react-bootstrap/Button";
+import {
+  createRole,
+  deleteRole,
+  listRoles,
+  updateRole,
+} from "../service/ApiService";
+
+const errorMessageFrom = (errorPayload) => {
+  if (!errorPayload) return "Something went wrong.";
+  if (errorPayload.error && errorPayload.error.message)
+    return errorPayload.error.message;
+  if (errorPayload.message) return errorPayload.message;
+  return "Something went wrong.";
+};
+
+const extractRoles = (data) => {
+  // GenericMessageResponseDTO wraps the payload under `data`.
+  const payload = (data && data.data) || data || [];
+  if (Array.isArray(payload)) return payload;
+  if (Array.isArray(payload.content)) return payload.content;
+  return [];
+};
+
+function Admin({ toastState, setToastState }) {
+  const [roles, setRoles] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [newRoleName, setNewRoleName] = useState("");
+  const [editing, setEditing] = useState({ id: null, name: "" });
+
+  const showSuccess = (message) =>
+    setToastState({
+      display: true,
+      variant: "success",
+      messages: [message],
+      includePrefix: false,
+      includeSuffix: false,
+      suffix: "",
+    });
+
+  const showError = (messages) =>
+    setToastState({
+      display: true,
+      variant: "error",
+      messages: Array.isArray(messages) ? messages : [messages],
+      includePrefix: true,
+      includeSuffix: false,
+      suffix: "",
+    });
+
+  const load = useCallback(() => {
+    setLoading(true);
+    listRoles((data, err) => {
+      setLoading(false);
+      if (err) {
+        showError(errorMessageFrom(err));
+        return;
+      }
+      setRoles(extractRoles(data));
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleCreate = (e) => {
+    e.preventDefault();
+    if (!newRoleName.trim()) {
+      showError("Role name is required.");
+      return;
+    }
+    createRole({ roleName: newRoleName.trim() }, (data, err) => {
+      if (err) {
+        showError(errorMessageFrom(err));
+        return;
+      }
+      showSuccess("Role created.");
+      setNewRoleName("");
+      load();
+    });
+  };
+
+  const handleSaveRename = (e) => {
+    e.preventDefault();
+    if (!editing.id) return;
+    if (!editing.name.trim()) {
+      showError("Role name is required.");
+      return;
+    }
+    updateRole(
+      { roleId: editing.id, roleName: editing.name.trim() },
+      (data, err) => {
+        if (err) {
+          showError(errorMessageFrom(err));
+          return;
+        }
+        showSuccess("Role updated.");
+        setEditing({ id: null, name: "" });
+        load();
+      }
+    );
+  };
+
+  const handleDelete = (role) => {
+    if (
+      !window.confirm(`Soft-delete role "${role.name}"? Users with this role will lose it.`)
+    )
+      return;
+    deleteRole(role.id, (data, err) => {
+      if (err) {
+        showError(errorMessageFrom(err));
+        return;
+      }
+      showSuccess("Role removed.");
+      load();
+    });
+  };
+
+  return (
+    <div className="mtm-min-h-[80vh] mtm-bg-black mtm-text-white mtm-py-12 mtm-px-4 sm:mtm-px-12">
+      <div className="mtm-max-w-3xl mtm-mx-auto">
+        <h1 className="mtm-text-3xl mtm-tracking-wider mtm-text-sky-400 mtm-mb-8">
+          Admin · Roles
+        </h1>
+
+        <form
+          onSubmit={handleCreate}
+          className="mtm-bg-white/5 mtm-border mtm-border-white/20 mtm-rounded mtm-p-6 mtm-mb-8 mtm-flex mtm-flex-col sm:mtm-flex-row mtm-gap-3 sm:mtm-items-end"
+        >
+          <label className="mtm-flex mtm-flex-col mtm-flex-1">
+            <span className="mtm-text-sm mtm-text-white/70 mtm-mb-1">
+              New role name
+            </span>
+            <input
+              type="text"
+              value={newRoleName}
+              placeholder="MTM_NEW_ROLE"
+              onChange={(e) => setNewRoleName(e.target.value)}
+              className="mtm-bg-black mtm-border mtm-border-white/30 mtm-rounded mtm-px-3 mtm-py-2"
+            />
+          </label>
+          <Button type="submit" variant="warning">
+            Create role
+          </Button>
+        </form>
+
+        {loading && <p className="mtm-text-white/60">Loading roles…</p>}
+        {!loading && roles.length === 0 && (
+          <p className="mtm-text-white/60">No roles defined.</p>
+        )}
+
+        <ul className="mtm-space-y-3">
+          {roles.map((role) => (
+            <li
+              key={role.id}
+              className="mtm-bg-white/5 mtm-border mtm-border-white/20 mtm-rounded mtm-p-4 mtm-flex mtm-flex-col sm:mtm-flex-row sm:mtm-justify-between sm:mtm-items-center mtm-gap-3"
+            >
+              {editing.id === role.id ? (
+                <form
+                  onSubmit={handleSaveRename}
+                  className="mtm-flex mtm-flex-1 mtm-gap-2"
+                >
+                  <input
+                    type="text"
+                    value={editing.name}
+                    onChange={(e) =>
+                      setEditing((s) => ({ ...s, name: e.target.value }))
+                    }
+                    className="mtm-flex-1 mtm-bg-black mtm-border mtm-border-white/30 mtm-rounded mtm-px-3 mtm-py-2"
+                  />
+                  <Button type="submit" size="sm" variant="warning">
+                    Save
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline-light"
+                    onClick={() => setEditing({ id: null, name: "" })}
+                  >
+                    Cancel
+                  </Button>
+                </form>
+              ) : (
+                <>
+                  <div>
+                    <div className="mtm-text-lg mtm-text-white">{role.name}</div>
+                    <div className="mtm-text-xs mtm-text-white/50">{role.id}</div>
+                  </div>
+                  <div className="mtm-flex mtm-gap-2">
+                    <Button
+                      size="sm"
+                      variant="outline-warning"
+                      onClick={() =>
+                        setEditing({ id: role.id, name: role.name })
+                      }
+                    >
+                      Rename
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline-danger"
+                      onClick={() => handleDelete(role)}
+                    >
+                      Delete
+                    </Button>
+                  </div>
+                </>
+              )}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+export default Admin;

--- a/frontend/src/Pages/App.js
+++ b/frontend/src/Pages/App.js
@@ -11,7 +11,9 @@ import Registration from "./Registration";
 import Dashboard from "./Dashboard";
 import Activity from "./Activity";
 import Profile from "./Profile";
+import Admin from "./Admin";
 import ProtectedRoute from "../components/ProtectedRoute";
+import AdminRoute from "../components/AdminRoute";
 import { useState } from "react";
 import Toast from "../components/Toast";
 
@@ -93,6 +95,17 @@ function App() {
                 setToastState={setToastState}
               />
             </ProtectedRoute>
+          }
+        ></Route>
+        <Route
+          path={"/admin"}
+          element={
+            <AdminRoute>
+              <Admin
+                toastState={toastState}
+                setToastState={setToastState}
+              />
+            </AdminRoute>
           }
         ></Route>
       </Routes>

--- a/frontend/src/components/AdminRoute.js
+++ b/frontend/src/components/AdminRoute.js
@@ -1,0 +1,24 @@
+import React from "react";
+import { Navigate, useLocation } from "react-router-dom";
+import useAuth from "../hooks/useAuth";
+
+export default function AdminRoute({ children }) {
+  const { isAuthenticated, isAdmin, profileLoaded } = useAuth();
+  const location = useLocation();
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace state={{ from: location }} />;
+  }
+  // Wait for the profile fetch to settle so we don't bounce admins on first paint.
+  if (!profileLoaded) {
+    return (
+      <div className="mtm-min-h-[60vh] mtm-bg-black mtm-text-white mtm-py-20 mtm-text-center">
+        Loading…
+      </div>
+    );
+  }
+  if (!isAdmin) {
+    return <Navigate to="/dashboard" replace />;
+  }
+  return children;
+}

--- a/frontend/src/components/NavigationBar.js
+++ b/frontend/src/components/NavigationBar.js
@@ -14,7 +14,7 @@ const twButton =
 
 function NavigationBar() {
   const [toggled, setToggled] = useState(0);
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, isAdmin } = useAuth();
   const navigate = useNavigate();
 
   const handleLogout = async () => {
@@ -88,8 +88,21 @@ function NavigationBar() {
                   </Button>
                 </Link>
               </Nav.Link>
+              {isAdmin && (
+                <Nav.Link
+                  eventKey={4}
+                  className="mtm-mx-auto mtm-my-4 md:mtm-my-0"
+                  as={"div"}
+                >
+                  <Link to={"/admin"} preventScrollReset>
+                    <Button variant="warning" size="md" className={twButton}>
+                      <span className="mtm-tracking-widest">Admin</span>
+                    </Button>
+                  </Link>
+                </Nav.Link>
+              )}
               <Nav.Link
-                eventKey={4}
+                eventKey={5}
                 className="mtm-mx-auto mtm-my-4 md:mtm-my-0"
                 as={"div"}
               >

--- a/frontend/src/hooks/useAuth.js
+++ b/frontend/src/hooks/useAuth.js
@@ -1,8 +1,13 @@
 import { useEffect, useState } from "react";
 import { isAuthenticated, subscribeAuth } from "../service/AuthStorage";
+import { getUserProfile } from "../service/ApiService";
+
+const ADMIN_ROLE = "MTM_ADMIN_OPS";
 
 export default function useAuth() {
   const [authed, setAuthed] = useState(isAuthenticated());
+  const [roles, setRoles] = useState([]);
+  const [profileLoaded, setProfileLoaded] = useState(false);
 
   useEffect(() => {
     const update = () => setAuthed(isAuthenticated());
@@ -11,5 +16,37 @@ export default function useAuth() {
     return unsubscribe;
   }, []);
 
-  return { isAuthenticated: authed };
+  useEffect(() => {
+    let cancelled = false;
+    if (!authed) {
+      setRoles([]);
+      setProfileLoaded(false);
+      return;
+    }
+    setProfileLoaded(false);
+    getUserProfile((data, err) => {
+      if (cancelled) return;
+      setProfileLoaded(true);
+      if (err) {
+        setRoles([]);
+        return;
+      }
+      const payload = (data && data.data) || data || {};
+      const incomingRoles = Array.isArray(payload.roles)
+        ? payload.roles
+        : payload.roles
+        ? Array.from(payload.roles)
+        : [];
+      setRoles(incomingRoles);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [authed]);
+
+  const isAdmin = roles.some(
+    (r) => r === ADMIN_ROLE || r === `ROLE_${ADMIN_ROLE}`
+  );
+
+  return { isAuthenticated: authed, roles, isAdmin, profileLoaded };
 }

--- a/frontend/src/service/ApiService.js
+++ b/frontend/src/service/ApiService.js
@@ -188,5 +188,35 @@ export const changeUserPassword = async (payload, callback) => {
     .catch((err) => callback(null, toErrorPayload(err)));
 };
 
+// --- Role admin API ---
+
+export const listRoles = async (callback, page = 0, size = 50) => {
+  apiClient
+    .get(`/role`, { params: { page, size } })
+    .then((response) => callback(response.data, null))
+    .catch((err) => callback(null, toErrorPayload(err)));
+};
+
+export const createRole = async (payload, callback) => {
+  apiClient
+    .post(`/role`, payload)
+    .then((response) => callback(response.data, null))
+    .catch((err) => callback(null, toErrorPayload(err)));
+};
+
+export const updateRole = async (payload, callback) => {
+  apiClient
+    .put(`/role`, payload)
+    .then((response) => callback(response.data, null))
+    .catch((err) => callback(null, toErrorPayload(err)));
+};
+
+export const deleteRole = async (roleId, callback) => {
+  apiClient
+    .delete(`/role`, { params: { roleId } })
+    .then((response) => callback(response.data, null))
+    .catch((err) => callback(null, toErrorPayload(err)));
+};
+
 export { getAccessToken, isAuthenticated } from "./AuthStorage";
 export default apiClient;


### PR DESCRIPTION
Backend
-------
TDD: added 8 RoleServiceImpl tests up-front covering createNewRole, getRoleById, getAllRoles, deleteRole (soft-delete via isActive), and updateRoleDetails (rename happy path, no-op when name unchanged, conflict when another active role owns the name, not-found when id missing). All pass against the existing implementation.

* UserDTO.roles is no longer @JsonIgnore so /user/profile exposes the authenticated user's role names. The frontend needs these to decide whether to show the Admin nav link and gate the /admin route. Roles aren't sensitive — they're the same role identifiers the backend checks anyway.

Frontend
--------
* service/ApiService.js: added listRoles, createRole, updateRole, deleteRole wrappers around the shared apiClient.
* hooks/useAuth.js: now also fetches /user/profile when authenticated and exposes { isAuthenticated, roles, isAdmin, profileLoaded }. isAdmin matches MTM_ADMIN_OPS with or without the ROLE_ prefix to be robust to how the backend names them.
* components/AdminRoute.js (new): protected-route wrapper that additionally requires isAdmin. Waits for profileLoaded so admins don't get bounced to /dashboard on first paint before the profile fetch settles.
* Pages/Admin.js (new): role management page — list, create (inline form), rename (inline edit), soft-delete (with confirm). Toast feedback for every success/error.
* Pages/App.js: registered /admin behind AdminRoute.
* components/NavigationBar.js: Admin nav link rendered only when isAdmin is true (Dashboard | Activity | Profile | [Admin] | Logout).

Verification
------------
* mvn -q test -Dtest=RoleServiceImplTest: 8/8 pass.
* mvn -q test (full suite): 59 total, 8 failing — same 8 pre-existing flaky cases (SessionServiceImplTest x7 + ApiServiceApplicationTests Mongo dependency x1). No new failures.
* npm run build: clean, no new ESLint warnings.