### PR TITLE
feat(activity): paginated history endpoint + /history page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,6 +130,7 @@ GET    /api/v1/activity/getAllForDate?date= Get activities for date (ACTIVITY_CR
 PUT    /api/v1/activity?date=             Update activity — body: ActivityUpdateRequestDTO (recordId + optional name/description/times) (ACTIVITY_CRUD)
 DELETE /api/v1/activity?date=&recordId=   Delete activity from record (ACTIVITY_CRUD)
 GET    /api/v1/activity/stats?from=&to=   Aggregate stats over window (defaults to last 7 days) (ACTIVITY_CRUD)
+GET    /api/v1/activity/history?page=&size= Paginated per-day history, newest first (ACTIVITY_CRUD)
 
 POST   /api/v1/admin/                     Create role via admin (ADMIN_OPS) [legacy, use /role]
 DELETE /api/v1/admin/                     Soft-delete role via admin (ADMIN_OPS) [legacy]
@@ -189,7 +190,8 @@ src/
 │   ├── Login.js           Login form — wired to /auth/login + redirect to /dashboard (or location.state.from)
 │   ├── Registration.js    Registration form — API fully wired
 │   ├── Dashboard.js       Protected landing page — Today / 7d / 30d preset stat cards (total time, activity count, days tracked, avg/active day), top activities by duration, recent activities. Wired to /activity/stats.
-│   ├── Activity.js        Protected page — date picker + list + create/edit/delete activities
+│   ├── Activity.js        Protected page — date picker + list + create/edit/delete activities. Reads `?date=YYYY-MM-DD` from URL (set by the History page deep-link) and keeps the URL in sync with the picker.
+│   ├── History.js         Protected page — paginated list of every tracked day, newest first. Each row links into /activity?date=. Page-size selector (10/20/50) + prev/next.
 │   ├── Profile.js         Protected page — view/edit profile + change password
 │   ├── Admin.js           Admin-only page — tabbed UI: Roles (CRUD: list/create/rename/soft-delete) + Users (paginated list, edit each user's role membership with checkbox diff)
 │   └── sections/home/     Home page sections (Top, HowItWorks, ButWhy, NextSteps)
@@ -220,7 +222,8 @@ src/
 /login      → Login (public)
 /register   → Registration (public)
 /dashboard  → Dashboard (protected)
-/activity   → Activity tracker (protected)
+/activity   → Activity tracker (protected; accepts `?date=YYYY-MM-DD`)
+/history    → Paginated activity history (protected)
 /profile    → User profile + password change (protected)
 /admin      → Role management (admin-only, gated by ROLE_MTM_ADMIN_OPS)
 ```
@@ -276,8 +279,9 @@ Toast state lives in `App.js` and is passed as `{ toastState, setToastState }` p
 - [x] Activity Record: read by date (scoped to current user)
 - [x] Activity Record: delete individual activity from record
 - [x] Activity Record: update individual activity (metadata-only or full re-time, reuses overlap/ordering validation from create pipeline; deletes the record outright if the re-time empties it so the create-pipeline doesn't false-positive on "overlap")
-- [x] ActivityRecordServiceImpl test suite (18 tests covering create happy path / append / duplicate / overlap / invalid date, get-by-date happy + missing, delete happy + missing + unknown id, update metadata-only / full retime / unknown id / overlap rejection, **plus stats aggregation across a window / invalid from date / inverted window / empty window**) + ActivityTestFactory
+- [x] ActivityRecordServiceImpl test suite (21 tests covering create happy path / append / duplicate / overlap / invalid date, get-by-date happy + missing, delete happy + missing + unknown id, update metadata-only / full retime / unknown id / overlap rejection, stats aggregation across a window / invalid from date / inverted window / empty window, **plus history happy path / null-activities defensive / empty history**) + ActivityTestFactory
 - [x] **Activity stats endpoint** — `GET /api/v1/activity/stats?from=&to=` (both bounds optional; default = rolling last 7 days). Returns total minutes / activity count / days-with-activity / avg-per-active-day, top 5 activities by total time (grouped by name, case-insensitive), and 5 most-recent activities (newest first). Backed by a new `ActivityRecordRepository.findByCreatedByAndRecordDateBetween` range query. Powers the dashboard.
+- [x] **Activity history endpoint** — `GET /api/v1/activity/history?page=&size=` returns a paginated list of per-day summaries (recordDate, activityCount, totalMinutes, totalDurationHuman, lastUpdatedAt) for the current user, newest day first. Sort is always recordDate DESC regardless of what the caller passes — recordDate is stored as ISO-8601 strings so lexical sort matches calendar order. Backed by a new `ActivityRecordRepository.findByCreatedBy(String, Pageable)` paginated query.
 - [x] **`UserServiceImpl.updateUserDetails` horizontal-IDOR closed**: service now reads the authenticated principal's uid from SecurityContext and rejects any request body whose uid doesn't match (returns `MicroTimeManagementUserException` -> 409). The previous dead `currentUser.getUid().equals(...)` check (always true since the record was just looked up by uid) was removed.
 - [x] **`UserController.updateUser` accepts `@RequestBody`** — was implicitly binding from query parameters.
 - [x] **`UserServiceImpl.changeUserPassword`** now throws `MicroTimeManagementBadRequestException` (400) on a wrong old password instead of silently returning the SOMETHING_WENT_WRONG string with HTTP 200, and now persists the new password via `userRepository.save`.
@@ -309,9 +313,10 @@ Toast state lives in `App.js` and is passed as `{ toastState, setToastState }` p
 - [x] `useAuth` hook + `ProtectedRoute` wrapper (redirects to `/login`, preserves intended destination)
 - [x] `/dashboard` placeholder route protected by `ProtectedRoute`; Login redirects there post-auth
 - [x] **Dashboard summary page** — Today / 7d / 30d preset ranges, stat cards (total time, activity count, days tracked, avg/active day), top activities by total time, recent activities. Wired to `getActivityStats`.
-- [x] **Activity tracker page** — date-scoped CRUD UI at `/activity`, full create/edit/delete flow with toast feedback
-- [x] `ApiService.js` extended with Activity API functions (`createActivity`, `getActivitiesForDate`, `updateActivity`, `deleteActivity`)
-- [x] Nav link to Activity tracker shown when authenticated
+- [x] **Activity tracker page** — date-scoped CRUD UI at `/activity`, full create/edit/delete flow with toast feedback. Now reads the active date from `?date=YYYY-MM-DD` and writes it back as the picker changes (replaces URL state, no extra history entries), so deep-links from the History page work and back/forward navigation re-loads the right day.
+- [x] **Activity history page** — `/history` shows a paginated list of every day the current user has tracked, newest first, with page-size selector (10/20/50) and prev/next controls. Each row deep-links into `/activity?date=YYYY-MM-DD`. Empty state nudges users to the tracker. Wired to `getActivityHistory`.
+- [x] `ApiService.js` extended with Activity API functions (`createActivity`, `getActivitiesForDate`, `updateActivity`, `deleteActivity`, `getActivityHistory`)
+- [x] Nav links to Activity tracker + History shown when authenticated
 - [x] **Profile page** — view/edit account details (username/email/first/last/DOB) + change-password panel at `/profile`, with client-side new-password confirm + length check
 - [x] `ApiService.js` extended with Profile API functions (`getUserProfile`, `updateUserDetails`, `changeUserPassword`)
 - [x] Nav link to Profile shown when authenticated
@@ -356,7 +361,6 @@ These are real correctness/security issues identified in a code review. Address 
 - [ ] Populate `SecurityConstants.PROD` (currently empty class) and use it in prod filter chain
 - [ ] `AdminController` is legacy (predates `RoleController`) — evaluate removing or consolidating
 - [ ] Add integration tests for Activity, Role, Admin endpoints
-- [ ] Paginate activity records (get all records across dates)
 - [ ] User UID generation is handled by callbacks but `uid` field isn't visible in `UserCallbacks` — verify it is auto-populated
 - [ ] Prod Docker Compose (app service commented out — needs env vars wired)
 

--- a/backend/api-service/src/main/java/com/microtimemanagement/apiservice/controller/ActivityRecordController.java
+++ b/backend/api-service/src/main/java/com/microtimemanagement/apiservice/controller/ActivityRecordController.java
@@ -1,11 +1,15 @@
 package com.microtimemanagement.apiservice.controller;
 
 import com.microtimemanagement.apiservice.constants.ApiConstants;
+import com.microtimemanagement.apiservice.constants.PaginationConstants;
 import com.microtimemanagement.apiservice.dto.request.ActivityRecordCreationRequestDTO;
 import com.microtimemanagement.apiservice.dto.request.ActivityUpdateRequestDTO;
+import com.microtimemanagement.apiservice.dto.response.ActivityHistoryItemDTO;
 import com.microtimemanagement.apiservice.dto.response.ActivityRecordCreationdResponseDTO;
 import com.microtimemanagement.apiservice.dto.response.ActivityRecordResponseDTO;
 import com.microtimemanagement.apiservice.dto.response.ActivityStatsResponseDTO;
+import com.microtimemanagement.apiservice.dto.response.PaginationRequestFieldsSanitizationResponseDTO;
+import com.microtimemanagement.apiservice.dto.response.PaginationResultResponseDTO;
 import com.microtimemanagement.apiservice.exceptions.MicroTimeManagementBadRequestException;
 import com.microtimemanagement.apiservice.service.ActivityRecordService;
 import com.microtimemanagement.apiservice.utils.ApiUtils;
@@ -13,6 +17,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
@@ -82,6 +87,24 @@ public class ActivityRecordController {
             @RequestParam(required = false) String to
     ){
         return activityRecordService.getActivityStats(from, to);
+    }
+
+    /**
+     * Paginated history of every day the current user has tracked, newest first.
+     * Returns lightweight per-day summaries (count + total minutes), not the
+     * full activity list — clients deep-link into /activity/getAllForDate.
+     */
+    @RequestMapping(value = "/history", method = RequestMethod.GET)
+    @ResponseBody
+    public PaginationResultResponseDTO<ActivityHistoryItemDTO> getHistory(
+            @RequestParam(name = "page", required = false, defaultValue = PaginationConstants.DEFAULT_PAGE_NUMBER) Integer pageNumber,
+            @RequestParam(name = "size", required = false, defaultValue = PaginationConstants.DEFAULT_PAGE_SIZE) Integer pageSize
+    ){
+        PaginationRequestFieldsSanitizationResponseDTO sanitized = ApiUtils
+                .sanitizePaginationRequestFields(pageNumber, pageSize);
+        return activityRecordService.getActivityHistory(
+                PageRequest.of(sanitized.getPageNumber(), sanitized.getPageSize())
+        );
     }
 
 }

--- a/backend/api-service/src/main/java/com/microtimemanagement/apiservice/dto/response/ActivityHistoryItemDTO.java
+++ b/backend/api-service/src/main/java/com/microtimemanagement/apiservice/dto/response/ActivityHistoryItemDTO.java
@@ -1,0 +1,31 @@
+package com.microtimemanagement.apiservice.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+/**
+ * One-row summary of a user's activity for a single day. Powers the paginated
+ * history view — the goal is "did I track time on this day, how much, how many
+ * entries" without shipping the full activity list. Click-through on the
+ * frontend then loads the full record via /activity/getAllForDate.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ActivityHistoryItemDTO {
+
+    private String recordDate;
+
+    private Integer activityCount;
+
+    private Long totalMinutes;
+
+    private String totalDurationHuman;
+
+    private Date lastUpdatedAt;
+}

--- a/backend/api-service/src/main/java/com/microtimemanagement/apiservice/repository/ActivityRecordRepository.java
+++ b/backend/api-service/src/main/java/com/microtimemanagement/apiservice/repository/ActivityRecordRepository.java
@@ -1,6 +1,8 @@
 package com.microtimemanagement.apiservice.repository;
 
 import com.microtimemanagement.apiservice.model.ActivityRecord;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
@@ -21,4 +23,11 @@ public interface ActivityRecordRepository extends MongoRepository<ActivityRecord
      */
     List<ActivityRecord> findByCreatedByAndRecordDateBetween(
             String createdBy, String fromDate, String toDate);
+
+    /**
+     * Paginated lookup of every record a user owns, ordered by Spring's
+     * Pageable sort. The history endpoint pins this to recordDate DESC so the
+     * latest day surfaces first.
+     */
+    Page<ActivityRecord> findByCreatedBy(String createdBy, Pageable pageable);
 }

--- a/backend/api-service/src/main/java/com/microtimemanagement/apiservice/service/ActivityRecordService.java
+++ b/backend/api-service/src/main/java/com/microtimemanagement/apiservice/service/ActivityRecordService.java
@@ -2,10 +2,13 @@ package com.microtimemanagement.apiservice.service;
 
 import com.microtimemanagement.apiservice.dto.request.ActivityRecordCreationRequestDTO;
 import com.microtimemanagement.apiservice.dto.request.ActivityUpdateRequestDTO;
+import com.microtimemanagement.apiservice.dto.response.ActivityHistoryItemDTO;
 import com.microtimemanagement.apiservice.dto.response.ActivityRecordCreationdResponseDTO;
 import com.microtimemanagement.apiservice.dto.response.ActivityRecordResponseDTO;
 import com.microtimemanagement.apiservice.dto.response.ActivityStatsResponseDTO;
+import com.microtimemanagement.apiservice.dto.response.PaginationResultResponseDTO;
 import com.microtimemanagement.apiservice.model.ActivityRecord;
+import org.springframework.data.domain.PageRequest;
 
 import java.text.ParseException;
 
@@ -27,4 +30,11 @@ public interface ActivityRecordService {
      * sensible default window (rolling 7 days) when both are null.
      */
     ActivityStatsResponseDTO getActivityStats(String fromDate, String toDate);
+
+    /**
+     * Paginated history of the current user's tracked days, newest day first.
+     * Each item is a per-day roll-up (count + total minutes) rather than the
+     * full activity list — the frontend deep-links into /activity for detail.
+     */
+    PaginationResultResponseDTO<ActivityHistoryItemDTO> getActivityHistory(PageRequest pageRequest);
 }

--- a/backend/api-service/src/main/java/com/microtimemanagement/apiservice/service/impl/ActivityRecordServiceImpl.java
+++ b/backend/api-service/src/main/java/com/microtimemanagement/apiservice/service/impl/ActivityRecordServiceImpl.java
@@ -6,9 +6,11 @@ import com.microtimemanagement.apiservice.dto.entity.ActivityDTO;
 import com.microtimemanagement.apiservice.dto.entity.UserDTO;
 import com.microtimemanagement.apiservice.dto.request.ActivityRecordCreationRequestDTO;
 import com.microtimemanagement.apiservice.dto.request.ActivityUpdateRequestDTO;
+import com.microtimemanagement.apiservice.dto.response.ActivityHistoryItemDTO;
 import com.microtimemanagement.apiservice.dto.response.ActivityRecordCreationdResponseDTO;
 import com.microtimemanagement.apiservice.dto.response.ActivityRecordResponseDTO;
 import com.microtimemanagement.apiservice.dto.response.ActivityStatsResponseDTO;
+import com.microtimemanagement.apiservice.dto.response.PaginationResultResponseDTO;
 import com.microtimemanagement.apiservice.exceptions.MicroTimeManagementBadRequestException;
 import com.microtimemanagement.apiservice.exceptions.MicroTimeManagementException;
 import com.microtimemanagement.apiservice.exceptions.MicroTimeManagementNotFoundException;
@@ -22,6 +24,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.time.DateFormatUtils;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
@@ -504,6 +509,54 @@ public class ActivityRecordServiceImpl implements ActivityRecordService {
                 .averageMinutesPerActiveDay(avgPerActiveDay)
                 .topActivitiesByDuration(topByDuration)
                 .recentActivities(recent.stream().map(activityConverter::toDTO).toList())
+                .build();
+    }
+
+    @Override
+    public PaginationResultResponseDTO<ActivityHistoryItemDTO> getActivityHistory(PageRequest pageRequest) {
+        // Always sort by recordDate DESC regardless of what the controller passed —
+        // recordDate is ISO-8601 strings so lexical sort matches calendar order, and
+        // "newest day first" is the only ordering this view ever wants.
+        PageRequest sorted = PageRequest.of(
+                pageRequest.getPageNumber(),
+                pageRequest.getPageSize(),
+                Sort.by(Sort.Direction.DESC, "recordDate")
+        );
+
+        String userUid = userService.loadUserDTOByUsername(
+                SecurityContextHolder.getContext().getAuthentication().getName()
+        ).getUid();
+
+        Page<ActivityRecord> page = activityRecordRepository.findByCreatedBy(userUid, sorted);
+
+        List<ActivityHistoryItemDTO> items = page.getContent().stream()
+                .map(this::toHistoryItem)
+                .toList();
+
+        return PaginationResultResponseDTO.<ActivityHistoryItemDTO>builder()
+                .payload(items)
+                .pageNumber(page.getNumber())
+                .pageSize(page.getSize())
+                .totalPages(page.getTotalPages())
+                .sortingDirection(Sort.Direction.DESC.name())
+                .sortedByFields(List.of("recordDate"))
+                .build();
+    }
+
+    private ActivityHistoryItemDTO toHistoryItem(ActivityRecord record) {
+        List<Activity> activities = record.getActivities() == null
+                ? List.of() : record.getActivities();
+        long totalMinutes = activities.stream()
+                .filter(Objects::nonNull)
+                .mapToLong(a -> a.getTotalDurationInMinutes() == null
+                        ? 0L : a.getTotalDurationInMinutes())
+                .sum();
+        return ActivityHistoryItemDTO.builder()
+                .recordDate(record.getRecordDate())
+                .activityCount(activities.size())
+                .totalMinutes(totalMinutes)
+                .totalDurationHuman(humanizeMinutes(totalMinutes))
+                .lastUpdatedAt(record.getLastUpdatedAt())
                 .build();
     }
 

--- a/backend/api-service/src/test/java/com/microtimemanagement/apiservice/service/ActivityRecordServiceImplTest.java
+++ b/backend/api-service/src/test/java/com/microtimemanagement/apiservice/service/ActivityRecordServiceImplTest.java
@@ -5,9 +5,11 @@ import com.microtimemanagement.apiservice.converter.ActivityDTOConverter;
 import com.microtimemanagement.apiservice.dto.entity.UserDTO;
 import com.microtimemanagement.apiservice.dto.request.ActivityRecordCreationRequestDTO;
 import com.microtimemanagement.apiservice.dto.request.ActivityUpdateRequestDTO;
+import com.microtimemanagement.apiservice.dto.response.ActivityHistoryItemDTO;
 import com.microtimemanagement.apiservice.dto.response.ActivityRecordCreationdResponseDTO;
 import com.microtimemanagement.apiservice.dto.response.ActivityRecordResponseDTO;
 import com.microtimemanagement.apiservice.dto.response.ActivityStatsResponseDTO;
+import com.microtimemanagement.apiservice.dto.response.PaginationResultResponseDTO;
 import com.microtimemanagement.apiservice.exceptions.MicroTimeManagementBadRequestException;
 import com.microtimemanagement.apiservice.exceptions.MicroTimeManagementNotFoundException;
 import com.microtimemanagement.apiservice.factories.ActivityTestFactory;
@@ -28,6 +30,10 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 
@@ -526,5 +532,101 @@ public class ActivityRecordServiceImplTest {
         assertThat(stats.getTopActivitiesByDuration()).isEmpty();
         assertThat(stats.getRecentActivities()).isEmpty();
         assertThat(stats.getTotalDurationHuman()).isEqualTo("0m");
+    }
+
+    // -- getActivityHistory ------------------------------------------------
+
+    @Test
+    @DisplayName("Should return a paginated, newest-first history with per-day count + duration totals.")
+    void shouldReturnPaginatedActivityHistory() {
+        String dayOne = "2026-05-20";
+        String dayTwo = "2026-05-22";
+
+        Activity oneA = ActivityTestFactory.activity(dayOne, 9, 0, 10, 0);   // 60m
+        Activity oneB = ActivityTestFactory.activity(dayOne, 10, 30, 11, 0); // 30m
+        oneB.setTotalDurationInMinutes(30L);
+        ActivityRecord dayOneRecord =
+                ActivityTestFactory.recordForUser(authenticatedUser.getUid(), dayOne, oneA, oneB);
+
+        Activity twoA = ActivityTestFactory.activity(dayTwo, 9, 0, 10, 30);  // 90m
+        twoA.setTotalDurationInMinutes(90L);
+        ActivityRecord dayTwoRecord =
+                ActivityTestFactory.recordForUser(authenticatedUser.getUid(), dayTwo, twoA);
+
+        // Repo returns newest-first because the impl forces a DESC sort.
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        Mockito.when(activityRecordRepository.findByCreatedBy(
+                        Mockito.eq(authenticatedUser.getUid()), pageableCaptor.capture()))
+                .thenReturn(new PageImpl<>(List.of(dayTwoRecord, dayOneRecord),
+                        PageRequest.of(0, 10), 2));
+
+        PaginationResultResponseDTO<ActivityHistoryItemDTO> result =
+                activityRecordService.getActivityHistory(PageRequest.of(0, 10));
+
+        // Forced sort: recordDate DESC regardless of what the caller passed.
+        assertThat(pageableCaptor.getValue().getSort().getOrderFor("recordDate"))
+                .isNotNull()
+                .extracting(Sort.Order::getDirection)
+                .isEqualTo(Sort.Direction.DESC);
+
+        assertThat(result.getPageNumber()).isZero();
+        assertThat(result.getPageSize()).isEqualTo(10);
+        assertThat(result.getTotalPages()).isEqualTo(1);
+        assertThat(result.getSortingDirection()).isEqualTo("DESC");
+        assertThat(result.getSortedByFields()).containsExactly("recordDate");
+
+        assertThat(result.getPayload()).hasSize(2);
+
+        ActivityHistoryItemDTO first = result.getPayload().get(0);
+        assertThat(first.getRecordDate()).isEqualTo(dayTwo);
+        assertThat(first.getActivityCount()).isEqualTo(1);
+        assertThat(first.getTotalMinutes()).isEqualTo(90L);
+        assertThat(first.getTotalDurationHuman()).isEqualTo("1h 30m");
+
+        ActivityHistoryItemDTO second = result.getPayload().get(1);
+        assertThat(second.getRecordDate()).isEqualTo(dayOne);
+        assertThat(second.getActivityCount()).isEqualTo(2);
+        assertThat(second.getTotalMinutes()).isEqualTo(90L);
+        assertThat(second.getTotalDurationHuman()).isEqualTo("1h 30m");
+    }
+
+    @Test
+    @DisplayName("Should treat a null activities list as zero count + zero minutes instead of NPE-ing.")
+    void shouldHandleNullActivitiesListInHistory() {
+        ActivityRecord brokenRecord = ActivityRecord.builder()
+                .id("rec-1")
+                .recordDate("2026-05-15")
+                .createdBy(authenticatedUser.getUid())
+                .activities(null)
+                .build();
+
+        Mockito.when(activityRecordRepository.findByCreatedBy(
+                        Mockito.eq(authenticatedUser.getUid()), Mockito.any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(brokenRecord), PageRequest.of(0, 10), 1));
+
+        PaginationResultResponseDTO<ActivityHistoryItemDTO> result =
+                activityRecordService.getActivityHistory(PageRequest.of(0, 10));
+
+        assertThat(result.getPayload()).hasSize(1);
+        ActivityHistoryItemDTO item = result.getPayload().get(0);
+        assertThat(item.getActivityCount()).isZero();
+        assertThat(item.getTotalMinutes()).isZero();
+        assertThat(item.getTotalDurationHuman()).isEqualTo("0m");
+    }
+
+    @Test
+    @DisplayName("Should return an empty payload + metadata when the user has no records yet.")
+    void shouldReturnEmptyHistoryPayloadWhenNoRecords() {
+        Mockito.when(activityRecordRepository.findByCreatedBy(
+                        Mockito.eq(authenticatedUser.getUid()), Mockito.any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(), PageRequest.of(0, 10), 0));
+
+        PaginationResultResponseDTO<ActivityHistoryItemDTO> result =
+                activityRecordService.getActivityHistory(PageRequest.of(0, 10));
+
+        assertThat(result.getPayload()).isEmpty();
+        assertThat(result.getTotalPages()).isZero();
+        assertThat(result.getSortingDirection()).isEqualTo("DESC");
+        assertThat(result.getSortedByFields()).containsExactly("recordDate");
     }
 }

--- a/frontend/src/Pages/Activity.js
+++ b/frontend/src/Pages/Activity.js
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useState } from "react";
 import Button from "react-bootstrap/Button";
+import { useSearchParams } from "react-router-dom";
 import {
   createActivity,
   deleteActivity,
@@ -28,6 +29,13 @@ const todayIsoDate = () => {
   return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`;
 };
 
+// Accept only yyyy-MM-dd strings on the way in from the URL — anything else
+// (truncated value, copy-paste from another locale) falls back to today so we
+// never round-trip junk into the backend.
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const sanitizeDateParam = (raw) =>
+  raw && ISO_DATE_RE.test(raw) ? raw : todayIsoDate();
+
 const blankForm = () => ({
   activityName: "",
   activityDescription: "",
@@ -36,7 +44,10 @@ const blankForm = () => ({
 });
 
 function Activity({ toastState, setToastState }) {
-  const [date, setDate] = useState(todayIsoDate());
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [date, setDate] = useState(() =>
+    sanitizeDateParam(searchParams.get("date"))
+  );
   const [activities, setActivities] = useState([]);
   const [loading, setLoading] = useState(false);
   const [creating, setCreating] = useState(false);
@@ -97,6 +108,16 @@ function Activity({ toastState, setToastState }) {
   useEffect(() => {
     loadActivities(date);
   }, [date, loadActivities]);
+
+  // Pick up date changes that come from outside the date picker — e.g. the
+  // browser back button after a click from the History page.
+  useEffect(() => {
+    const fromUrl = sanitizeDateParam(searchParams.get("date"));
+    if (fromUrl !== date) {
+      setDate(fromUrl);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams]);
 
   const resetForm = () => {
     setForm(blankForm());
@@ -194,7 +215,13 @@ function Activity({ toastState, setToastState }) {
             <input
               type="date"
               value={date}
-              onChange={(e) => setDate(e.target.value)}
+              onChange={(e) => {
+                const next = e.target.value;
+                setDate(next);
+                // Keep the URL in sync so the date is shareable/back-navigable.
+                if (next) setSearchParams({ date: next }, { replace: true });
+                else setSearchParams({}, { replace: true });
+              }}
               className="mtm-bg-black mtm-text-white mtm-border mtm-border-sky-400 mtm-rounded mtm-px-3 mtm-py-1 mtm-ml-2"
             />
           </label>

--- a/frontend/src/Pages/App.js
+++ b/frontend/src/Pages/App.js
@@ -10,6 +10,7 @@ import Login from "./Login";
 import Registration from "./Registration";
 import Dashboard from "./Dashboard";
 import Activity from "./Activity";
+import History from "./History";
 import Profile from "./Profile";
 import Admin from "./Admin";
 import ProtectedRoute from "../components/ProtectedRoute";
@@ -83,6 +84,17 @@ function App() {
           element={
             <ProtectedRoute>
               <Activity
+                toastState={toastState}
+                setToastState={setToastState}
+              />
+            </ProtectedRoute>
+          }
+        ></Route>
+        <Route
+          path={"/history"}
+          element={
+            <ProtectedRoute>
+              <History
                 toastState={toastState}
                 setToastState={setToastState}
               />

--- a/frontend/src/Pages/History.js
+++ b/frontend/src/Pages/History.js
@@ -1,0 +1,173 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import Button from "react-bootstrap/Button";
+import { getActivityHistory } from "../service/ApiService";
+
+const PAGE_SIZE_OPTIONS = [10, 20, 50];
+
+const errorMessageFrom = (errorPayload) => {
+  if (!errorPayload) return "Something went wrong.";
+  if (errorPayload.error && errorPayload.error.message)
+    return errorPayload.error.message;
+  if (errorPayload.message) return errorPayload.message;
+  return "Something went wrong.";
+};
+
+function HistoryRow({ item, onOpen }) {
+  return (
+    <li
+      className="mtm-bg-white/5 mtm-border mtm-border-white/20 mtm-rounded mtm-p-4 mtm-flex mtm-flex-col sm:mtm-flex-row sm:mtm-justify-between sm:mtm-items-center mtm-gap-3 hover:mtm-bg-white/10 mtm-cursor-pointer mtm-transition"
+      onClick={() => onOpen(item.recordDate)}
+    >
+      <div>
+        <div className="mtm-text-lg mtm-text-white mtm-tracking-wider">
+          {item.recordDate}
+        </div>
+        <div className="mtm-text-sm mtm-text-white/70">
+          {item.activityCount} {item.activityCount === 1 ? "activity" : "activities"}
+          &nbsp;·&nbsp;
+          {item.totalDurationHuman || "0m"}
+        </div>
+      </div>
+      <Button
+        size="sm"
+        variant="outline-warning"
+        onClick={(e) => {
+          e.stopPropagation();
+          onOpen(item.recordDate);
+        }}
+      >
+        Open day
+      </Button>
+    </li>
+  );
+}
+
+function History({ toastState, setToastState }) {
+  const [items, setItems] = useState([]);
+  const [page, setPage] = useState(0);
+  const [size, setSize] = useState(10);
+  const [totalPages, setTotalPages] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const navigate = useNavigate();
+
+  const showError = useCallback(
+    (msg) =>
+      setToastState({
+        display: true,
+        variant: "error",
+        messages: [msg],
+        includePrefix: true,
+        includeSuffix: false,
+        suffix: "",
+      }),
+    [setToastState]
+  );
+
+  const load = useCallback(() => {
+    setLoading(true);
+    getActivityHistory({ page, size }, (data, err) => {
+      setLoading(false);
+      if (err) {
+        showError(errorMessageFrom(err));
+        setItems([]);
+        setTotalPages(0);
+        return;
+      }
+      // Backend returns PaginationResultResponseDTO: { results, page, size, totalPages }.
+      setItems((data && data.results) || []);
+      setTotalPages((data && data.totalPages) || 0);
+    });
+  }, [page, size, showError]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const openDay = (recordDate) => {
+    navigate(`/activity?date=${encodeURIComponent(recordDate)}`);
+  };
+
+  // totalPages is 0 when there are no records — clamp display to "1 / 1" so we
+  // don't render a confusing "Page 1 of 0".
+  const displayTotal = totalPages > 0 ? totalPages : 1;
+  const canPrev = page > 0;
+  const canNext = page + 1 < totalPages;
+
+  return (
+    <div className="mtm-min-h-[80vh] mtm-bg-black mtm-text-white mtm-py-12 mtm-px-4 sm:mtm-px-12">
+      <div className="mtm-max-w-4xl mtm-mx-auto">
+        <h1 className="mtm-text-3xl mtm-tracking-wider mtm-text-sky-400 mtm-mb-2">
+          Activity History
+        </h1>
+        <p className="mtm-text-white/60 mtm-mb-8">
+          Every day you've tracked, newest first. Click a row to open that day's activities.
+        </p>
+
+        <div className="mtm-flex mtm-flex-col sm:mtm-flex-row mtm-justify-between mtm-items-start sm:mtm-items-center mtm-mb-6 mtm-gap-3">
+          <label className="mtm-text-white/80 mtm-text-sm">
+            Page size:&nbsp;
+            <select
+              value={size}
+              onChange={(e) => {
+                setPage(0);
+                setSize(parseInt(e.target.value, 10));
+              }}
+              className="mtm-bg-black mtm-text-white mtm-border mtm-border-sky-400 mtm-rounded mtm-px-2 mtm-py-1 mtm-ml-1"
+            >
+              {PAGE_SIZE_OPTIONS.map((opt) => (
+                <option key={opt} value={opt}>
+                  {opt}
+                </option>
+              ))}
+            </select>
+          </label>
+          <div className="mtm-flex mtm-items-center mtm-gap-3">
+            <Button
+              size="sm"
+              variant="outline-light"
+              disabled={!canPrev || loading}
+              onClick={() => setPage((p) => Math.max(0, p - 1))}
+            >
+              ← Prev
+            </Button>
+            <span className="mtm-text-white/70 mtm-text-sm">
+              Page {page + 1} of {displayTotal}
+            </span>
+            <Button
+              size="sm"
+              variant="outline-light"
+              disabled={!canNext || loading}
+              onClick={() => setPage((p) => p + 1)}
+            >
+              Next →
+            </Button>
+          </div>
+        </div>
+
+        {loading && <p className="mtm-text-white/60">Loading history…</p>}
+
+        {!loading && items.length === 0 && (
+          <div className="mtm-bg-white/5 mtm-border mtm-border-white/20 mtm-rounded mtm-p-6 mtm-text-white/70">
+            No tracked days yet. Head to the{" "}
+            <span
+              className="mtm-text-yellow-300 mtm-cursor-pointer mtm-underline"
+              onClick={() => navigate("/activity")}
+            >
+              Activity tracker
+            </span>{" "}
+            to log your first one.
+          </div>
+        )}
+
+        <ul className="mtm-space-y-3">
+          {items.map((item) => (
+            <HistoryRow key={item.recordDate} item={item} onOpen={openDay} />
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+export default History;

--- a/frontend/src/components/NavigationBar.js
+++ b/frontend/src/components/NavigationBar.js
@@ -82,6 +82,17 @@ function NavigationBar() {
                 className="mtm-mx-auto mtm-my-4 md:mtm-my-0"
                 as={"div"}
               >
+                <Link to={"/history"} preventScrollReset>
+                  <Button variant="warning" size="md" className={twButton}>
+                    <span className="mtm-tracking-widest">History</span>
+                  </Button>
+                </Link>
+              </Nav.Link>
+              <Nav.Link
+                eventKey={4}
+                className="mtm-mx-auto mtm-my-4 md:mtm-my-0"
+                as={"div"}
+              >
                 <Link to={"/profile"} preventScrollReset>
                   <Button variant="warning" size="md" className={twButton}>
                     <span className="mtm-tracking-widest">Profile</span>
@@ -90,7 +101,7 @@ function NavigationBar() {
               </Nav.Link>
               {isAdmin && (
                 <Nav.Link
-                  eventKey={4}
+                  eventKey={5}
                   className="mtm-mx-auto mtm-my-4 md:mtm-my-0"
                   as={"div"}
                 >
@@ -102,7 +113,7 @@ function NavigationBar() {
                 </Nav.Link>
               )}
               <Nav.Link
-                eventKey={5}
+                eventKey={6}
                 className="mtm-mx-auto mtm-my-4 md:mtm-my-0"
                 as={"div"}
               >

--- a/frontend/src/service/ApiService.js
+++ b/frontend/src/service/ApiService.js
@@ -192,6 +192,18 @@ export const getActivityStats = async (
     .catch((err) => callback(null, toErrorPayload(err)));
 };
 
+// Paginated history of tracked days (newest first). Powers the /history page —
+// each item is { recordDate, activityCount, totalMinutes, totalDurationHuman }.
+export const getActivityHistory = async (
+  { page = 0, size = 10 } = {},
+  callback = () => {}
+) => {
+  apiClient
+    .get(`/activity/history`, { params: { page, size } })
+    .then((response) => callback(response.data, null))
+    .catch((err) => callback(null, toErrorPayload(err)));
+};
+
 // --- User profile API ---
 
 export const getUserProfile = async (callback) => {


### PR DESCRIPTION
Backend: GET /api/v1/activity/history?page=&size= returns per-day summaries (date, count, totalMinutes, totalDurationHuman, lastUpdatedAt) for the current user, recordDate DESC. Forces the sort regardless of caller — recordDate is ISO-8601 so lexical order matches calendar. Backed by new ActivityRecordRepository.findByCreatedBy(String, Pageable). 3 new service tests (happy path + null-activities defensive + empty).

Frontend: new /history route + page with prev/next + page-size selector. Each row deep-links into /activity?date=YYYY-MM-DD. Activity page now reads ?date= from the URL and writes it back as the picker changes (replace, not push) so back/forward and shared links work.