### PR TITLE
fix(activity): base-path routing 500 on create/update/delete

### DIFF
--- a/backend/api-service/src/main/java/com/microtimemanagement/apiservice/controller/ActivityRecordController.java
+++ b/backend/api-service/src/main/java/com/microtimemanagement/apiservice/controller/ActivityRecordController.java
@@ -39,7 +39,11 @@ public class ActivityRecordController {
 
     private final ActivityRecordService activityRecordService;
 
-    @RequestMapping(value = ApiConstants.EMPTY_BASE, method = RequestMethod.POST)
+    // Bare @PostMapping maps to the class base path with no trailing slash.
+    // Using EMPTY_BASE ("/") would map to "/api/v1/activity/", which Spring
+    // Boot 3 no longer matches against the trailing-slash-less request the
+    // clients send — see RoleController for the same (correct) pattern.
+    @PostMapping
     @ResponseBody
     public ActivityRecordCreationdResponseDTO saveRecord(
             @Valid @RequestBody ActivityRecordCreationRequestDTO activityRecordCreationRequestDTO
@@ -55,7 +59,7 @@ public class ActivityRecordController {
         return activityRecordService.getActivitiesForDate(date);
     }
 
-    @RequestMapping(value = ApiConstants.EMPTY_BASE, method = RequestMethod.PUT)
+    @PutMapping
     @ResponseBody
     public ActivityRecordResponseDTO updateActivity(
             @RequestParam String date,
@@ -67,7 +71,7 @@ public class ActivityRecordController {
     }
 
 
-    @RequestMapping(value = ApiConstants.EMPTY_BASE, method = RequestMethod.DELETE)
+    @DeleteMapping
     @ResponseBody
     public ActivityRecordResponseDTO deleteActivityById(
             @RequestParam String date,

--- a/backend/api-service/src/main/java/com/microtimemanagement/apiservice/controller/AdminController.java
+++ b/backend/api-service/src/main/java/com/microtimemanagement/apiservice/controller/AdminController.java
@@ -18,19 +18,22 @@ public class AdminController {
 
     final AdminService adminService;
 
-    @RequestMapping(value = ApiConstants.EMPTY_BASE, method = RequestMethod.POST)
+    // Bare mappings map to the class base path with no trailing slash. EMPTY_BASE
+    // ("/") would produce "/api/v1/admin/", which Spring Boot 3 no longer matches
+    // against a trailing-slash-less request.
+    @PostMapping
     @ResponseBody
     public RoleDTO createNew(@RequestBody RoleRequestDTO requestDTO){
         return adminService.createNew(requestDTO);
     }
 
-    @RequestMapping(value = ApiConstants.EMPTY_BASE, method = RequestMethod.DELETE)
+    @DeleteMapping
     @ResponseBody
     public RoleDTO deleteRole(@RequestBody RoleRequestDTO requestDTO){
         return adminService.setInactive(requestDTO.getName());
     }
 
-    @RequestMapping(value = ApiConstants.EMPTY_BASE, method = RequestMethod.GET)
+    @GetMapping
     @ResponseBody
     public RoleDTO getRole(@RequestParam String roleName){
         return adminService.getDTOByName(roleName);

--- a/backend/api-service/src/test/java/com/microtimemanagement/apiservice/controller/ActivityRecordControllerRoutingTest.java
+++ b/backend/api-service/src/test/java/com/microtimemanagement/apiservice/controller/ActivityRecordControllerRoutingTest.java
@@ -1,0 +1,74 @@
+package com.microtimemanagement.apiservice.controller;
+
+import com.microtimemanagement.apiservice.service.ActivityRecordService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Routing-only regression tests for {@link ActivityRecordController}.
+ *
+ * <p>The create/update/delete handlers live at the controller's base path.
+ * They used to be mapped via {@code EMPTY_BASE} ("/"), which combined to
+ * "/api/v1/activity/" — a trailing-slash path Spring Boot 3 no longer matches
+ * against the slash-less request every client sends, so POST/PUT/DELETE fell
+ * through to the static-resource handler and 500'd. These tests pin the
+ * base-path mappings (no trailing slash) so that never silently regresses.
+ *
+ * Standalone MockMvc mirrors production path matching (PathPatternParser,
+ * trailing-slash matching off) without needing MongoDB or the security filter.
+ */
+@DisplayName("Activity Record Controller routing")
+class ActivityRecordControllerRoutingTest {
+
+    private final ActivityRecordService activityRecordService =
+            Mockito.mock(ActivityRecordService.class);
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new ActivityRecordController(activityRecordService))
+                .build();
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/activity (no trailing slash) resolves to the create handler")
+    void postToBasePathIsMapped() throws Exception {
+        mockMvc.perform(post("/api/v1/activity")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"recordDate\":\"2026-07-22\",\"activityName\":\"Standup\","
+                                + "\"activityStartHourMinutes\":\"09:00:0\","
+                                + "\"activityEndHourMinutes\":\"09:30:0\"}"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("PUT /api/v1/activity (no trailing slash) resolves to the update handler")
+    void putToBasePathIsMapped() throws Exception {
+        mockMvc.perform(put("/api/v1/activity")
+                        .param("date", "2026-07-22")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"recordId\":\"abc123\"}"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("DELETE /api/v1/activity (no trailing slash) resolves to the delete handler")
+    void deleteToBasePathIsMapped() throws Exception {
+        mockMvc.perform(delete("/api/v1/activity")
+                        .param("date", "2026-07-22")
+                        .param("recordId", "abc123"))
+                .andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
## The bug
Creating an activity failed with **500 `No static resource api/v1/activity`**, and the dashboard then showed no activities (downstream of the failed create).

## Root cause
`POST/PUT/DELETE /api/v1/activity` were mapped via `EMPTY_BASE = "/"`, combining with the class base to `/api/v1/activity/` (trailing slash). Spring Boot 3 disabled trailing-slash matching, so the slash-less request clients send didn't match and fell through to the static-resource handler → 500. (Service unit tests never exercised MVC routing, so it went unnoticed; `RoleController` used bare `@PostMapping` and was unaffected.)

## Fix
- Bare `@PostMapping`/`@PutMapping`/`@DeleteMapping` on the activity base-path handlers (matches the working `RoleController`). Same fix for the legacy `AdminController`.
- Standalone-MockMvc **routing regression test** pinning the base-path mappings (mirrors production path matching; no Mongo/security needed).

## Verified
Against the running Docker stack: `POST /activity` → 200 with the created activity; `getAllForDate` returns it. Full backend suite green (now 83 tests).