### PR TITLE
Reminders — in-app + browser notifications, email stubbed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,6 +166,12 @@ POST   /api/v1/link                          Create workflow link (ACTIVITY_CRUD
 GET    /api/v1/link[?sourceType=&sourceId=]  List links — all / originating from an entity (ACTIVITY_CRUD)
 DELETE /api/v1/link/{id}                     Soft-delete link (ACTIVITY_CRUD)
 
+POST   /api/v1/reminder                      Create reminder (ACTIVITY_CRUD)
+GET    /api/v1/reminder                      List current user's reminders, soonest first (ACTIVITY_CRUD)
+GET    /api/v1/reminder/{id}                 Get reminder (ACTIVITY_CRUD)
+PUT    /api/v1/reminder/{id}                 Update reminder — partial incl. status (ACTIVITY_CRUD)
+DELETE /api/v1/reminder/{id}                 Soft-delete reminder (ACTIVITY_CRUD)
+
 POST   /api/v1/admin/                     Create role via admin (ADMIN_OPS) [legacy, use /role]
 DELETE /api/v1/admin/                     Soft-delete role via admin (ADMIN_OPS) [legacy]
 GET    /api/v1/admin/?roleName=           Get role by name (ADMIN_OPS) [legacy]
@@ -274,6 +280,7 @@ src/
 /history    → Paginated activity history (protected)
 /projects   → Projects grid + create (protected)
 /projects/:id → Project detail — task board (TODO/In-progress/Done) + sub-tasks (protected)
+/reminders  → Reminders — schedule + in-app/browser notify (protected)
 /profile    → User profile + password change (protected)
 /admin      → Role management (admin-only, gated by ROLE_MTM_ADMIN_OPS)
 ```
@@ -501,6 +508,7 @@ The following are not in this feature. If they become desirable later, they get 
 - [x] **GitHub Actions CI** (`.github/workflows/ci.yml`) — backend job runs `mvnw test` (against in-memory H2, no DB service needed) then packages; frontend job runs `yarn test` + `yarn build`. Triggers on every push and PRs to `main`.
 - [x] **Activity create cross-user scoping bug fixed** — the create pipeline looked up the existing day-record via `findByRecordDate(date)` (no owner filter), so a user creating an activity on a date another user already had a record for would collide with ("Record already exists") or append into that other user's record — routing the activity under the wrong `createdBy` so it never showed in the owner's History. Now scoped via `findByRecordDateAndCreatedBy(date, currentUid)` (the unscoped repo finder was removed). `recordDate` is a literal `yyyy-MM-dd` string end-to-end, so this was a scoping bug, not a timezone one. Verified: two users can log the same time on the same date independently and each sees only their own in `getAllForDate` + History.
 - [x] **Activity base-path routing 500 fixed** — `POST/PUT/DELETE /api/v1/activity` were mapped via `EMPTY_BASE ("/")` → `/api/v1/activity/`, which Spring Boot 3 no longer matches against the slash-less request, so create/update/delete 500'd with "No static resource" and the dashboard showed nothing. Now bare `@PostMapping`/`@PutMapping`/`@DeleteMapping` (same as `RoleController`); legacy `AdminController` fixed too. Standalone-MockMvc routing regression test added.
+- [x] **Reminders (in-app + browser + email stub)** — new user-owned `Reminder` entity (title, `remindAt` epoch ms, notes, `status` PENDING/DONE/DISMISSED, `emailReminder` flag, optional linked entity), owner-scoped CRUD at `/api/v1/reminder` (`ReminderService`/controller, gated under ACTIVITY_CRUD), 5 service tests. **Email is stubbed**: `email/EmailSender` + `LoggingEmailSender` (logs only) + a `@Scheduled` `ReminderEmailScheduler` (60s, `mtm.reminders.email-poll-ms`) that marks due email-reminders processed so nothing double-sends — README documents wiring real SMTP via a `@Primary` `JavaMailSender` impl. `@EnableScheduling` added. Frontend: `/reminders` page (create with datetime + email toggle, mark done/dismiss, delete) + `useReminderNotifications` hook that requests Web Notification permission and fires an in-app toast + browser notification for due reminders while the app is open. Nav link added.
 - [x] **Activity chaining** — each activity row gets a **"Next"** action that opens the create form pre-filled with that activity's end time as the new start time (back-to-back logging). On save, a `FOLLOWS` `EntityLink` (ACTIVITY→ACTIVITY) is persisted between the two, so the chain is recorded as a workflow link. `ApiService` gains `createLink`/`listLinks`.
 - [x] **Activity image attachments** — activities can carry an optional image stored as a data-URL base64 string (`Activity.imageBase64`, a `text` column), capped at **5 MB** via `@Size(max=7_000_000)` on the create + update request DTOs. Threaded through the create pipeline (single + day-one split), the update path (metadata set + full-retime carry-through), the DTO/converter. Frontend: a file picker with size check + preview/remove in the activity form, and a clickable thumbnail on each activity row.
 - [x] **Dashboard charts + add-to-calendar** — the dashboard gains a dependency-free **"Time per day"** bar chart (single-hue, primary→accent gradient, rounded bars, per-bar hover; zero-days included) and renders **top activities** as horizontal magnitude bars. Backed by a new `dailyBreakdown` field on the stats response (`ActivityStatsResponseDTO.DailyStatDTO` — every date in the window incl. zeros). Each activity row also gets an **"Add to Google Calendar"** link (opens a pre-filled `calendar.google.com/render` event). Charts follow the dataviz method (single series → one hue, no legend, text in ink tokens).

--- a/README.md
+++ b/README.md
@@ -257,6 +257,42 @@ The dev profile (`application-dev.yml`) ships with sensible defaults so you can 
 
 > The dev JWT secret has been left in the repo intentionally so the app boots out of the box. **Override it in any environment you don't fully control.**
 
+### Email reminders (optional — stubbed by default)
+
+Reminders always fire **in-app + browser notifications** while MTM is open (no setup). The **email** channel is **stubbed**: `LoggingEmailSender` just logs `[EMAIL STUB — not actually sent]`, and a `@Scheduled` job (`ReminderEmailScheduler`, every 60s — tune with `MTM_REMINDERS_EMAIL_POLL_MS`) marks due email-reminders as processed so nothing double-sends.
+
+To send **real** email (before or after deploy):
+
+1. Add the dependency to `backend/api-service/pom.xml`:
+   ```xml
+   <dependency>
+     <groupId>org.springframework.boot</groupId>
+     <artifactId>spring-boot-starter-mail</artifactId>
+   </dependency>
+   ```
+2. Provide SMTP config via env (e.g. in `docker-compose.yml` under `mtm_backend`):
+   ```
+   SPRING_MAIL_HOST=smtp.yourprovider.com
+   SPRING_MAIL_PORT=587
+   SPRING_MAIL_USERNAME=apikey-or-user
+   SPRING_MAIL_PASSWORD=secret
+   SPRING_MAIL_PROPERTIES_MAIL_SMTP_AUTH=true
+   SPRING_MAIL_PROPERTIES_MAIL_SMTP_STARTTLS_ENABLE=true
+   ```
+   (SendGrid/Mailgun/Amazon SES all expose an SMTP endpoint that fits these.)
+3. Add a `@Primary @Component` implementing `com.microtimemanagement.apiservice.email.EmailSender` backed by Spring's `JavaMailSender` — it overrides the stub with **no other code changes**:
+   ```java
+   @Primary @Component @RequiredArgsConstructor
+   class SmtpEmailSender implements EmailSender {
+     private final JavaMailSender mail;
+     public void send(String to, String subject, String body) {
+       var msg = new SimpleMailMessage();
+       msg.setTo(to); msg.setSubject(subject); msg.setText(body);
+       mail.send(msg);
+     }
+   }
+   ```
+
 ## API surface
 
 A trimmed map of the v1 API — full schemas live in the Swagger UI.

--- a/backend/api-service/src/main/java/com/microtimemanagement/apiservice/ApiServiceApplication.java
+++ b/backend/api-service/src/main/java/com/microtimemanagement/apiservice/ApiServiceApplication.java
@@ -8,9 +8,11 @@ import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 @SpringBootApplication
+@EnableScheduling
 @OpenAPIDefinition(info = @Info(title = "MTM API", description = "APIs for managing time."))
 @SecurityScheme(name = "MTM Auth",paramName = "Authorization",type = SecuritySchemeType.APIKEY, in = SecuritySchemeIn.HEADER)
 public class ApiServiceApplication {

--- a/backend/api-service/src/main/java/com/microtimemanagement/apiservice/constants/ApiConstants.java
+++ b/backend/api-service/src/main/java/com/microtimemanagement/apiservice/constants/ApiConstants.java
@@ -42,6 +42,10 @@ public class ApiConstants {
     public static final class LinkEndpoint {
         public static final String API_BASE = API_PREFIX_V1 + "/link";
     }
+
+    public static final class ReminderEndpoint {
+        public static final String API_BASE = API_PREFIX_V1 + "/reminder";
+    }
     public static final class AuthEndpoint {
         public static final String API_BASE = API_PREFIX_V1 + "/auth";
         public static final String LOGIN = "/login";

--- a/backend/api-service/src/main/java/com/microtimemanagement/apiservice/constants/ErrorConstants.java
+++ b/backend/api-service/src/main/java/com/microtimemanagement/apiservice/constants/ErrorConstants.java
@@ -30,6 +30,8 @@ public class ErrorConstants {
     public static final String TASK_NOT_FOUND = "No task found.";
 
     public static final String LINK_NOT_FOUND = "No link found.";
+
+    public static final String REMINDER_NOT_FOUND = "No reminder found.";
     public static final String PLEASE_FIX_THE_FOLLOWING_ERRORS = "Please fix the following errors:";
     public static final String SESSION_EXPIRY_CANNOT_BE_NULL = "Session expiry date cannot be null.";
     public static final String PASSWORD_CANNOT_BE_BLANK = "Password cannot be Blank.";

--- a/backend/api-service/src/main/java/com/microtimemanagement/apiservice/constants/SecurityConstants.java
+++ b/backend/api-service/src/main/java/com/microtimemanagement/apiservice/constants/SecurityConstants.java
@@ -69,6 +69,9 @@ public class SecurityConstants {
                 ),
                 ApiUtils.getRequestMatcherPatternForBase(
                         ApiConstants.LinkEndpoint.API_BASE
+                ),
+                ApiUtils.getRequestMatcherPatternForBase(
+                        ApiConstants.ReminderEndpoint.API_BASE
                 )
         };
 

--- a/backend/api-service/src/main/java/com/microtimemanagement/apiservice/controller/ReminderController.java
+++ b/backend/api-service/src/main/java/com/microtimemanagement/apiservice/controller/ReminderController.java
@@ -1,0 +1,46 @@
+package com.microtimemanagement.apiservice.controller;
+
+import com.microtimemanagement.apiservice.constants.ApiConstants;
+import com.microtimemanagement.apiservice.dto.entity.ReminderDTO;
+import com.microtimemanagement.apiservice.service.ReminderService;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@SecurityRequirement(name = "MTM Auth")
+@RequestMapping(ApiConstants.ReminderEndpoint.API_BASE)
+@Tag(name = "Reminder", description = "Future reminders (in-app + optional email)")
+public class ReminderController {
+
+    private final ReminderService reminderService;
+
+    @PostMapping
+    public ReminderDTO create(@RequestBody ReminderDTO dto) {
+        return reminderService.create(dto);
+    }
+
+    @GetMapping
+    public List<ReminderDTO> list() {
+        return reminderService.listForCurrentUser();
+    }
+
+    @GetMapping("/{id}")
+    public ReminderDTO get(@PathVariable String id) {
+        return reminderService.getById(id);
+    }
+
+    @PutMapping("/{id}")
+    public ReminderDTO update(@PathVariable String id, @RequestBody ReminderDTO dto) {
+        return reminderService.update(id, dto);
+    }
+
+    @DeleteMapping("/{id}")
+    public void delete(@PathVariable String id) {
+        reminderService.softDelete(id);
+    }
+}

--- a/backend/api-service/src/main/java/com/microtimemanagement/apiservice/dto/entity/ReminderDTO.java
+++ b/backend/api-service/src/main/java/com/microtimemanagement/apiservice/dto/entity/ReminderDTO.java
@@ -1,0 +1,29 @@
+package com.microtimemanagement.apiservice.dto.entity;
+
+import com.microtimemanagement.apiservice.enums.LinkableType;
+import com.microtimemanagement.apiservice.enums.ReminderStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReminderDTO {
+
+    private String id;
+    private String title;
+    private String notes;
+    private Long remindAt;
+    private ReminderStatus status;
+    private Boolean emailReminder;
+    private LinkableType linkedType;
+    private String linkedId;
+    private Date createdAt;
+    private Date lastUpdatedAt;
+    private Boolean isActive;
+}

--- a/backend/api-service/src/main/java/com/microtimemanagement/apiservice/email/EmailSender.java
+++ b/backend/api-service/src/main/java/com/microtimemanagement/apiservice/email/EmailSender.java
@@ -1,0 +1,15 @@
+package com.microtimemanagement.apiservice.email;
+
+/**
+ * Outbound email abstraction. The default implementation ({@link LoggingEmailSender})
+ * is a STUB that only logs — no email actually leaves the app.
+ *
+ * <p>To send real email (before or after deploy), see the setup notes in the
+ * README ("Email reminders"): add {@code spring-boot-starter-mail}, configure
+ * {@code spring.mail.*} from env, and provide a {@code JavaMailSender}-backed
+ * implementation of this interface (it will be picked up in place of the stub).
+ */
+public interface EmailSender {
+
+    void send(String to, String subject, String body);
+}

--- a/backend/api-service/src/main/java/com/microtimemanagement/apiservice/email/LoggingEmailSender.java
+++ b/backend/api-service/src/main/java/com/microtimemanagement/apiservice/email/LoggingEmailSender.java
@@ -1,0 +1,27 @@
+package com.microtimemanagement.apiservice.email;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * STUB {@link EmailSender}: logs the message instead of sending it — no email
+ * actually leaves the app.
+ *
+ * <p>Enabling real email later (see README "Email reminders"):
+ * <pre>
+ *   1. add dependency: org.springframework.boot:spring-boot-starter-mail
+ *   2. set env: SPRING_MAIL_HOST / SPRING_MAIL_PORT / SPRING_MAIL_USERNAME /
+ *      SPRING_MAIL_PASSWORD (+ spring.mail.properties.mail.smtp.* as needed)
+ *   3. add an @Primary @Component implementing EmailSender backed by
+ *      JavaMailSender — it overrides this stub with no other code changes.
+ * </pre>
+ */
+@Slf4j
+@Component
+public class LoggingEmailSender implements EmailSender {
+
+    @Override
+    public void send(String to, String subject, String body) {
+        log.info("[EMAIL STUB — not actually sent] to='{}' subject='{}' body='{}'", to, subject, body);
+    }
+}

--- a/backend/api-service/src/main/java/com/microtimemanagement/apiservice/email/ReminderEmailScheduler.java
+++ b/backend/api-service/src/main/java/com/microtimemanagement/apiservice/email/ReminderEmailScheduler.java
@@ -1,0 +1,53 @@
+package com.microtimemanagement.apiservice.email;
+
+import com.microtimemanagement.apiservice.enums.ReminderStatus;
+import com.microtimemanagement.apiservice.model.Reminder;
+import com.microtimemanagement.apiservice.model.User;
+import com.microtimemanagement.apiservice.repository.ReminderRepository;
+import com.microtimemanagement.apiservice.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+import java.util.List;
+
+/**
+ * Polls for due, still-pending reminders that asked for an email and dispatches
+ * them via {@link EmailSender} (a logging stub by default), marking each so it
+ * is never emailed twice. Poll interval is {@code mtm.reminders.email-poll-ms}
+ * (default 60s).
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReminderEmailScheduler {
+
+    private final ReminderRepository reminderRepository;
+    private final UserRepository userRepository;
+    private final EmailSender emailSender;
+
+    @Scheduled(fixedDelayString = "${mtm.reminders.email-poll-ms:60000}")
+    public void dispatchDueReminderEmails() {
+        List<Reminder> due = reminderRepository
+                .findByIsActiveTrueAndEmailReminderTrueAndEmailSentAtIsNullAndStatusAndRemindAtLessThanEqual(
+                        ReminderStatus.PENDING, System.currentTimeMillis());
+        if (due.isEmpty()) {
+            return;
+        }
+        log.info("Dispatching {} due reminder email(s).", due.size());
+        for (Reminder reminder : due) {
+            User owner = userRepository.findByUidAndIsActiveTrue(reminder.getOwner());
+            if (owner != null && StringUtils.isNotBlank(owner.getEmail())) {
+                emailSender.send(
+                        owner.getEmail(),
+                        "Reminder: " + StringUtils.defaultString(reminder.getTitle()),
+                        StringUtils.defaultString(reminder.getNotes()));
+            }
+            reminder.setEmailSentAt(new Date());
+            reminderRepository.save(reminder);
+        }
+    }
+}

--- a/backend/api-service/src/main/java/com/microtimemanagement/apiservice/enums/ReminderStatus.java
+++ b/backend/api-service/src/main/java/com/microtimemanagement/apiservice/enums/ReminderStatus.java
@@ -1,0 +1,7 @@
+package com.microtimemanagement.apiservice.enums;
+
+public enum ReminderStatus {
+    PENDING,
+    DONE,
+    DISMISSED
+}

--- a/backend/api-service/src/main/java/com/microtimemanagement/apiservice/model/Reminder.java
+++ b/backend/api-service/src/main/java/com/microtimemanagement/apiservice/model/Reminder.java
@@ -1,0 +1,68 @@
+package com.microtimemanagement.apiservice.model;
+
+import com.microtimemanagement.apiservice.enums.LinkableType;
+import com.microtimemanagement.apiservice.enums.ReminderStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.util.Date;
+
+/**
+ * A future, time-bound reminder owned by (scoped to) a single user. Can
+ * optionally reference another entity (a task/activity/project) it's about.
+ * When {@code emailReminder} is set, a scheduled job emails the owner once
+ * {@code remindAt} passes (see ReminderEmailScheduler + EmailSender).
+ */
+@Data
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "mtm_reminder")
+@EqualsAndHashCode(callSuper = true)
+public class Reminder extends BaseModel {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private String id;
+
+    private String title;
+
+    @Column(length = 2000)
+    private String notes;
+
+    /** When to remind, epoch milliseconds. */
+    private Long remindAt;
+
+    @Enumerated(EnumType.STRING)
+    private ReminderStatus status;
+
+    /** Also email the owner when it fires. */
+    private Boolean emailReminder;
+
+    /** Set once the reminder email has been sent, so we never double-send. */
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date emailSentAt;
+
+    // Optional entity this reminder is about.
+    @Enumerated(EnumType.STRING)
+    private LinkableType linkedType;
+
+    private String linkedId;
+
+    /** Owning user's uid. */
+    private String owner;
+}

--- a/backend/api-service/src/main/java/com/microtimemanagement/apiservice/repository/ReminderRepository.java
+++ b/backend/api-service/src/main/java/com/microtimemanagement/apiservice/repository/ReminderRepository.java
@@ -1,0 +1,24 @@
+package com.microtimemanagement.apiservice.repository;
+
+import com.microtimemanagement.apiservice.enums.ReminderStatus;
+import com.microtimemanagement.apiservice.model.Reminder;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface ReminderRepository extends JpaRepository<Reminder, String> {
+
+    List<Reminder> findByOwnerAndIsActiveTrueOrderByRemindAtAsc(String owner);
+
+    Optional<Reminder> findByIdAndOwnerAndIsActiveTrue(String id, String owner);
+
+    /**
+     * Due, still-pending reminders that want an email and haven't been emailed
+     * yet — the scheduler's work queue.
+     */
+    List<Reminder> findByIsActiveTrueAndEmailReminderTrueAndEmailSentAtIsNullAndStatusAndRemindAtLessThanEqual(
+            ReminderStatus status, Long now);
+}

--- a/backend/api-service/src/main/java/com/microtimemanagement/apiservice/service/ReminderService.java
+++ b/backend/api-service/src/main/java/com/microtimemanagement/apiservice/service/ReminderService.java
@@ -1,0 +1,18 @@
+package com.microtimemanagement.apiservice.service;
+
+import com.microtimemanagement.apiservice.dto.entity.ReminderDTO;
+
+import java.util.List;
+
+public interface ReminderService {
+
+    ReminderDTO create(ReminderDTO dto);
+
+    List<ReminderDTO> listForCurrentUser();
+
+    ReminderDTO getById(String id);
+
+    ReminderDTO update(String id, ReminderDTO dto);
+
+    void softDelete(String id);
+}

--- a/backend/api-service/src/main/java/com/microtimemanagement/apiservice/service/impl/ReminderServiceImpl.java
+++ b/backend/api-service/src/main/java/com/microtimemanagement/apiservice/service/impl/ReminderServiceImpl.java
@@ -1,0 +1,95 @@
+package com.microtimemanagement.apiservice.service.impl;
+
+import com.microtimemanagement.apiservice.constants.ErrorConstants;
+import com.microtimemanagement.apiservice.dto.entity.ReminderDTO;
+import com.microtimemanagement.apiservice.enums.ReminderStatus;
+import com.microtimemanagement.apiservice.exceptions.MicroTimeManagementNotFoundException;
+import com.microtimemanagement.apiservice.model.Reminder;
+import com.microtimemanagement.apiservice.repository.ReminderRepository;
+import com.microtimemanagement.apiservice.service.ReminderService;
+import com.microtimemanagement.apiservice.utils.CurrentUserProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ReminderServiceImpl implements ReminderService {
+
+    private final ReminderRepository reminderRepository;
+    private final CurrentUserProvider currentUserProvider;
+
+    @Override
+    public ReminderDTO create(ReminderDTO dto) {
+        Reminder reminder = Reminder.builder()
+                .title(dto.getTitle())
+                .notes(dto.getNotes())
+                .remindAt(dto.getRemindAt())
+                .status(dto.getStatus() == null ? ReminderStatus.PENDING : dto.getStatus())
+                .emailReminder(Boolean.TRUE.equals(dto.getEmailReminder()))
+                .linkedType(dto.getLinkedType())
+                .linkedId(dto.getLinkedId())
+                .owner(currentUserProvider.currentUid())
+                .build();
+        return toDTO(reminderRepository.save(reminder));
+    }
+
+    @Override
+    public List<ReminderDTO> listForCurrentUser() {
+        return reminderRepository
+                .findByOwnerAndIsActiveTrueOrderByRemindAtAsc(currentUserProvider.currentUid())
+                .stream().map(this::toDTO).toList();
+    }
+
+    @Override
+    public ReminderDTO getById(String id) {
+        return toDTO(loadOwned(id));
+    }
+
+    @Override
+    public ReminderDTO update(String id, ReminderDTO dto) {
+        Reminder r = loadOwned(id);
+        if (dto.getTitle() != null) r.setTitle(dto.getTitle());
+        if (dto.getNotes() != null) r.setNotes(dto.getNotes());
+        if (dto.getRemindAt() != null) {
+            r.setRemindAt(dto.getRemindAt());
+            // Rescheduling clears the sent-marker so a moved reminder can email again.
+            r.setEmailSentAt(null);
+        }
+        if (dto.getStatus() != null) r.setStatus(dto.getStatus());
+        if (dto.getEmailReminder() != null) r.setEmailReminder(dto.getEmailReminder());
+        if (dto.getLinkedType() != null) r.setLinkedType(dto.getLinkedType());
+        if (dto.getLinkedId() != null) r.setLinkedId(dto.getLinkedId());
+        return toDTO(reminderRepository.save(r));
+    }
+
+    @Override
+    public void softDelete(String id) {
+        Reminder r = loadOwned(id);
+        r.setIsActive(Boolean.FALSE);
+        reminderRepository.save(r);
+    }
+
+    private Reminder loadOwned(String id) {
+        return reminderRepository
+                .findByIdAndOwnerAndIsActiveTrue(id, currentUserProvider.currentUid())
+                .orElseThrow(() -> new MicroTimeManagementNotFoundException(ErrorConstants.REMINDER_NOT_FOUND));
+    }
+
+    private ReminderDTO toDTO(Reminder r) {
+        return ReminderDTO.builder()
+                .id(r.getId())
+                .title(r.getTitle())
+                .notes(r.getNotes())
+                .remindAt(r.getRemindAt())
+                .status(r.getStatus())
+                .emailReminder(r.getEmailReminder())
+                .linkedType(r.getLinkedType())
+                .linkedId(r.getLinkedId())
+                .createdAt(r.getCreatedAt())
+                .lastUpdatedAt(r.getLastUpdatedAt())
+                .isActive(r.getIsActive())
+                .build();
+    }
+}

--- a/backend/api-service/src/test/java/com/microtimemanagement/apiservice/service/ReminderServiceImplTest.java
+++ b/backend/api-service/src/test/java/com/microtimemanagement/apiservice/service/ReminderServiceImplTest.java
@@ -1,0 +1,106 @@
+package com.microtimemanagement.apiservice.service;
+
+import com.microtimemanagement.apiservice.dto.entity.ReminderDTO;
+import com.microtimemanagement.apiservice.enums.ReminderStatus;
+import com.microtimemanagement.apiservice.exceptions.MicroTimeManagementNotFoundException;
+import com.microtimemanagement.apiservice.model.Reminder;
+import com.microtimemanagement.apiservice.repository.ReminderRepository;
+import com.microtimemanagement.apiservice.service.impl.ReminderServiceImpl;
+import com.microtimemanagement.apiservice.utils.CurrentUserProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.AdditionalAnswers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+@DisplayName("Reminder Service Tests")
+@ExtendWith(MockitoExtension.class)
+class ReminderServiceImplTest {
+
+    private static final String UID = "owner-uid-1";
+
+    @Mock
+    private ReminderRepository reminderRepository;
+
+    @Mock
+    private CurrentUserProvider currentUserProvider;
+
+    @InjectMocks
+    private ReminderServiceImpl reminderService;
+
+    @BeforeEach
+    void setUp() {
+        Mockito.lenient().when(currentUserProvider.currentUid()).thenReturn(UID);
+    }
+
+    @Test
+    @DisplayName("create defaults status PENDING, stamps owner, and coerces emailReminder")
+    void createDefaults() {
+        Mockito.when(reminderRepository.save(Mockito.any())).then(AdditionalAnswers.returnsFirstArg());
+
+        ReminderDTO result = reminderService.create(
+                ReminderDTO.builder().title("Dentist").remindAt(123L).build());
+
+        assertThat(result.getStatus()).isEqualTo(ReminderStatus.PENDING);
+        ArgumentCaptor<Reminder> captor = ArgumentCaptor.forClass(Reminder.class);
+        Mockito.verify(reminderRepository).save(captor.capture());
+        assertThat(captor.getValue().getOwner()).isEqualTo(UID);
+        assertThat(captor.getValue().getEmailReminder()).isFalse();
+    }
+
+    @Test
+    @DisplayName("list is scoped to the current user, ordered by remindAt")
+    void listScoped() {
+        Mockito.when(reminderRepository.findByOwnerAndIsActiveTrueOrderByRemindAtAsc(UID))
+                .thenReturn(List.of(Reminder.builder().id("r1").title("A").owner(UID).build()));
+
+        assertThat(reminderService.listForCurrentUser()).extracting(ReminderDTO::getId).containsExactly("r1");
+    }
+
+    @Test
+    @DisplayName("getById throws Not Found for a reminder not owned by the current user")
+    void getByIdNotFound() {
+        Mockito.when(reminderRepository.findByIdAndOwnerAndIsActiveTrue("nope", UID)).thenReturn(Optional.empty());
+
+        assertThatExceptionOfType(MicroTimeManagementNotFoundException.class)
+                .isThrownBy(() -> reminderService.getById("nope"));
+    }
+
+    @Test
+    @DisplayName("rescheduling (new remindAt) clears the email-sent marker so it can fire again")
+    void rescheduleClearsSentMarker() {
+        Reminder existing = Reminder.builder().id("r1").title("A").remindAt(100L)
+                .emailReminder(Boolean.TRUE).emailSentAt(new Date()).owner(UID).build();
+        Mockito.when(reminderRepository.findByIdAndOwnerAndIsActiveTrue("r1", UID)).thenReturn(Optional.of(existing));
+        Mockito.when(reminderRepository.save(Mockito.any())).then(AdditionalAnswers.returnsFirstArg());
+
+        reminderService.update("r1", ReminderDTO.builder().remindAt(200L).build());
+
+        assertThat(existing.getRemindAt()).isEqualTo(200L);
+        assertThat(existing.getEmailSentAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("softDelete flips isActive to false")
+    void softDelete() {
+        Reminder existing = Reminder.builder().id("r1").title("A").owner(UID).isActive(Boolean.TRUE).build();
+        Mockito.when(reminderRepository.findByIdAndOwnerAndIsActiveTrue("r1", UID)).thenReturn(Optional.of(existing));
+
+        reminderService.softDelete("r1");
+
+        assertThat(existing.getIsActive()).isFalse();
+        Mockito.verify(reminderRepository).save(existing);
+    }
+}

--- a/frontend/src/Pages/App.js
+++ b/frontend/src/Pages/App.js
@@ -11,12 +11,14 @@ import Activity from "./Activity";
 import History from "./History";
 import Projects from "./Projects";
 import ProjectDetail from "./ProjectDetail";
+import Reminders from "./Reminders";
 import Profile from "./Profile";
 import Admin from "./Admin";
 import ProtectedRoute from "../components/ProtectedRoute";
 import AdminRoute from "../components/AdminRoute";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import Toast from "../components/Toast";
+import useReminderNotifications from "../hooks/useReminderNotifications";
 
 function App() {
   const defaultToastState = {
@@ -30,6 +32,19 @@ function App() {
   const [toastState, setToastState] = useState(defaultToastState);
 
   const toastProps = { toastState, setToastState };
+
+  // App-wide: fire in-app + browser notifications for due reminders.
+  const onReminderFire = useCallback(
+    (r) =>
+      setToastState({
+        display: true,
+        variant: "success",
+        messages: [`Reminder: ${r.title}`],
+        includePrefix: false,
+      }),
+    []
+  );
+  useReminderNotifications({ onFire: onReminderFire });
 
   return (
     <div className="mtm-app-shell mtm-flex mtm-flex-col mtm-min-h-screen">
@@ -96,6 +111,14 @@ function App() {
             element={
               <ProtectedRoute>
                 <ProjectDetail {...toastProps} />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/reminders"
+            element={
+              <ProtectedRoute>
+                <Reminders {...toastProps} />
               </ProtectedRoute>
             }
           />

--- a/frontend/src/Pages/Reminders.js
+++ b/frontend/src/Pages/Reminders.js
@@ -1,0 +1,201 @@
+import React, { useCallback, useEffect, useState } from "react";
+import {
+  FiPlus,
+  FiBell,
+  FiTrash2,
+  FiCheck,
+  FiX,
+  FiMail,
+  FiClock,
+} from "react-icons/fi";
+import {
+  createReminder,
+  deleteReminder,
+  listReminders,
+  updateReminder,
+} from "../service/ApiService";
+
+const errorMessageFrom = (e) =>
+  (e && e.error && e.error.message) || (e && e.message) || "Something went wrong.";
+
+const fmt = (ms) => (ms ? new Date(ms).toLocaleString() : "");
+
+const relative = (ms) => {
+  if (!ms) return "";
+  const diff = ms - Date.now();
+  const abs = Math.abs(diff);
+  const mins = Math.round(abs / 60000);
+  const hrs = Math.round(abs / 3600000);
+  const days = Math.round(abs / 86400000);
+  const unit = mins < 60 ? `${mins}m` : hrs < 48 ? `${hrs}h` : `${days}d`;
+  return diff >= 0 ? `in ${unit}` : `${unit} ago`;
+};
+
+const STATUS_CHIP = {
+  PENDING: "mtm-text-primary",
+  DONE: "mtm-text-ok",
+  DISMISSED: "ui-muted",
+};
+
+function Reminders({ setToastState }) {
+  const [reminders, setReminders] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [form, setForm] = useState({ title: "", remindAtLocal: "", notes: "", emailReminder: false });
+
+  const showError = (m) =>
+    setToastState({ display: true, variant: "error", messages: [m], includePrefix: true });
+  const showSuccess = (m) => setToastState({ display: true, variant: "success", messages: [m] });
+
+  const load = useCallback(() => {
+    setLoading(true);
+    listReminders((data, err) => {
+      setLoading(false);
+      if (err) return showError(errorMessageFrom(err));
+      setReminders(Array.isArray(data) ? data : []);
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleCreate = (e) => {
+    e.preventDefault();
+    if (!form.title.trim()) return showError("Title is required.");
+    if (!form.remindAtLocal) return showError("Pick a date and time.");
+    const remindAt = new Date(form.remindAtLocal).getTime();
+    createReminder(
+      { title: form.title, notes: form.notes, remindAt, emailReminder: form.emailReminder },
+      (data, err) => {
+        if (err) return showError(errorMessageFrom(err));
+        showSuccess("Reminder set.");
+        setForm({ title: "", remindAtLocal: "", notes: "", emailReminder: false });
+        setCreating(false);
+        load();
+      }
+    );
+  };
+
+  const setStatus = (r, status) => {
+    updateReminder(r.id, { status }, (data, err) => {
+      if (err) return showError(errorMessageFrom(err));
+      load();
+    });
+  };
+
+  const remove = (r) => {
+    if (!window.confirm(`Delete reminder "${r.title}"?`)) return;
+    deleteReminder(r.id, (data, err) => {
+      if (err) return showError(errorMessageFrom(err));
+      showSuccess("Reminder deleted.");
+      load();
+    });
+  };
+
+  return (
+    <div className="ui-page ui-fade-in mtm-max-w-3xl">
+      <div className="mtm-flex mtm-flex-col sm:mtm-flex-row sm:mtm-items-end sm:mtm-justify-between mtm-gap-4 mtm-mb-8">
+        <div>
+          <p className="ui-eyebrow">Reminders</p>
+          <h1 className="mtm-text-3xl mtm-font-display mtm-font-bold mtm-text-content mtm-mt-1 mtm-mb-0">
+            Reminders
+          </h1>
+          <p className="ui-muted mtm-mt-1 mtm-mb-0">
+            Schedule nudges. You'll get an in-app + browser notification while MTM is open; email is optional.
+          </p>
+        </div>
+        <button className="ui-btn ui-btn-primary" onClick={() => setCreating((c) => !c)}>
+          <FiPlus size={18} /> New reminder
+        </button>
+      </div>
+
+      {creating && (
+        <form onSubmit={handleCreate} className="ui-card mtm-p-6 mtm-mb-8 mtm-grid mtm-gap-4 sm:mtm-grid-cols-2">
+          <div className="sm:mtm-col-span-2">
+            <label className="ui-label">Title</label>
+            <input className="ui-input" value={form.title}
+              onChange={(e) => setForm((s) => ({ ...s, title: e.target.value }))}
+              placeholder="e.g. Submit timesheet" />
+          </div>
+          <div>
+            <label className="ui-label">Remind me at</label>
+            <input type="datetime-local" className="ui-input" value={form.remindAtLocal}
+              onChange={(e) => setForm((s) => ({ ...s, remindAtLocal: e.target.value }))} />
+          </div>
+          <div className="mtm-flex mtm-items-end">
+            <label className="mtm-flex mtm-items-center mtm-gap-2 mtm-text-sm mtm-text-content mtm-pb-2">
+              <input type="checkbox" className="mtm-h-4 mtm-w-4 mtm-accent-primary"
+                checked={form.emailReminder}
+                onChange={(e) => setForm((s) => ({ ...s, emailReminder: e.target.checked }))} />
+              Also email me
+            </label>
+          </div>
+          <div className="sm:mtm-col-span-2">
+            <label className="ui-label">Notes</label>
+            <textarea className="ui-textarea" rows={2} value={form.notes}
+              onChange={(e) => setForm((s) => ({ ...s, notes: e.target.value }))} placeholder="Optional" />
+          </div>
+          <div className="sm:mtm-col-span-2 mtm-flex mtm-gap-2">
+            <button type="submit" className="ui-btn ui-btn-primary">Set reminder</button>
+            <button type="button" className="ui-btn ui-btn-ghost" onClick={() => setCreating(false)}>Cancel</button>
+          </div>
+        </form>
+      )}
+
+      {loading && <div className="ui-card mtm-p-10 mtm-text-center ui-muted">Loading reminders…</div>}
+
+      {!loading && reminders.length === 0 && (
+        <div className="ui-card mtm-p-10 mtm-text-center ui-muted">No reminders yet.</div>
+      )}
+
+      <ul className="mtm-flex mtm-flex-col mtm-gap-3 mtm-list-none mtm-p-0 mtm-m-0">
+        {reminders.map((r) => {
+          const overdue = r.status === "PENDING" && r.remindAt && r.remindAt <= Date.now();
+          return (
+            <li key={r.id} className="ui-card-flat mtm-p-4 mtm-flex mtm-flex-col sm:mtm-flex-row sm:mtm-justify-between sm:mtm-items-center mtm-gap-3">
+              <div className="mtm-flex mtm-items-start mtm-gap-3 mtm-min-w-0">
+                <span className={`ui-icon-tile mtm-shrink-0 mtm-mt-0.5 ${overdue ? "mtm-text-danger" : ""}`}>
+                  <FiBell size={17} />
+                </span>
+                <div className="mtm-min-w-0">
+                  <div className={`mtm-font-semibold ${r.status !== "PENDING" ? "ui-muted mtm-line-through" : "mtm-text-content"}`}>
+                    {r.title}
+                  </div>
+                  <div className="mtm-text-sm ui-muted mtm-flex mtm-flex-wrap mtm-items-center mtm-gap-x-2">
+                    <span className="mtm-inline-flex mtm-items-center mtm-gap-1">
+                      <FiClock size={12} /> {fmt(r.remindAt)}
+                    </span>
+                    <span className={STATUS_CHIP[r.status]}>· {relative(r.remindAt)}</span>
+                    {r.emailReminder && (
+                      <span className="mtm-inline-flex mtm-items-center mtm-gap-1"><FiMail size={12} /> email</span>
+                    )}
+                  </div>
+                  {r.notes && <div className="mtm-text-sm ui-muted mtm-mt-1">{r.notes}</div>}
+                </div>
+              </div>
+              <div className="mtm-flex mtm-gap-2 mtm-shrink-0">
+                {r.status === "PENDING" && (
+                  <>
+                    <button className="ui-btn ui-btn-soft ui-btn-sm" onClick={() => setStatus(r, "DONE")} title="Mark done">
+                      <FiCheck size={14} /> Done
+                    </button>
+                    <button className="ui-btn ui-btn-ghost ui-btn-sm" onClick={() => setStatus(r, "DISMISSED")} title="Dismiss">
+                      <FiX size={14} />
+                    </button>
+                  </>
+                )}
+                <button className="ui-btn ui-btn-danger ui-btn-sm" onClick={() => remove(r)} aria-label="Delete">
+                  <FiTrash2 size={14} />
+                </button>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+export default Reminders;

--- a/frontend/src/components/NavigationBar.js
+++ b/frontend/src/components/NavigationBar.js
@@ -9,6 +9,7 @@ const authedLinks = [
   { to: "/dashboard", label: "Dashboard" },
   { to: "/activity", label: "Activity" },
   { to: "/projects", label: "Projects" },
+  { to: "/reminders", label: "Reminders" },
   { to: "/history", label: "History" },
   { to: "/profile", label: "Profile" },
 ];

--- a/frontend/src/hooks/useReminderNotifications.js
+++ b/frontend/src/hooks/useReminderNotifications.js
@@ -1,0 +1,67 @@
+import { useEffect, useRef } from "react";
+import { isAuthenticated } from "../service/AuthStorage";
+import { listReminders } from "../service/ApiService";
+
+const FIRED_KEY = "mtm-fired-reminders";
+
+const loadFired = () => {
+  try {
+    return new Set(JSON.parse(localStorage.getItem(FIRED_KEY) || "[]"));
+  } catch (e) {
+    return new Set();
+  }
+};
+
+const saveFired = (set) => {
+  try {
+    localStorage.setItem(FIRED_KEY, JSON.stringify([...set]));
+  } catch (e) {
+    /* storage unavailable — non-fatal */
+  }
+};
+
+/**
+ * While the app is open and the user is authenticated, polls their reminders
+ * and fires a Web Notification (and an optional in-app callback) for any
+ * PENDING reminder whose time has passed. Fired ids are remembered in
+ * localStorage so a reminder never double-notifies across polls or reloads.
+ */
+export default function useReminderNotifications({ onFire } = {}) {
+  const firedRef = useRef(loadFired());
+
+  useEffect(() => {
+    if (!isAuthenticated()) return undefined;
+
+    if ("Notification" in window && Notification.permission === "default") {
+      Notification.requestPermission().catch(() => {});
+    }
+
+    let cancelled = false;
+    const poll = () => {
+      if (!isAuthenticated()) return;
+      listReminders((data, err) => {
+        if (cancelled || err || !Array.isArray(data)) return;
+        const now = Date.now();
+        data.forEach((r) => {
+          const due = r.status === "PENDING" && r.remindAt && r.remindAt <= now;
+          if (due && !firedRef.current.has(r.id)) {
+            firedRef.current.add(r.id);
+            saveFired(firedRef.current);
+            if ("Notification" in window && Notification.permission === "granted") {
+              // eslint-disable-next-line no-new
+              new Notification(`Reminder: ${r.title}`, { body: r.notes || "" });
+            }
+            if (onFire) onFire(r);
+          }
+        });
+      });
+    };
+
+    poll();
+    const id = setInterval(poll, 30000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [onFire]);
+}

--- a/frontend/src/service/ApiService.js
+++ b/frontend/src/service/ApiService.js
@@ -380,5 +380,34 @@ export const listLinks = async (params, callback = () => {}) => {
     .catch((err) => callback(null, toErrorPayload(err)));
 };
 
+// ---- Reminders ----
+export const listReminders = async (callback = () => {}) => {
+  apiClient
+    .get(`/reminder`)
+    .then((response) => callback(response.data, null))
+    .catch((err) => callback(null, toErrorPayload(err)));
+};
+
+export const createReminder = async (payload, callback = () => {}) => {
+  apiClient
+    .post(`/reminder`, payload)
+    .then((response) => callback(response.data, null))
+    .catch((err) => callback(null, toErrorPayload(err)));
+};
+
+export const updateReminder = async (id, payload, callback = () => {}) => {
+  apiClient
+    .put(`/reminder/${id}`, payload)
+    .then((response) => callback(response.data, null))
+    .catch((err) => callback(null, toErrorPayload(err)));
+};
+
+export const deleteReminder = async (id, callback = () => {}) => {
+  apiClient
+    .delete(`/reminder/${id}`)
+    .then((response) => callback(response.data, null))
+    .catch((err) => callback(null, toErrorPayload(err)));
+};
+
 export { getAccessToken, isAuthenticated } from "./AuthStorage";
 export default apiClient;


### PR DESCRIPTION
Adds scheduled reminders (all three delivery modes; **email is stubbed** with docs to enable it later, per your call).

## Backend
- New user-owned **`Reminder`** (title, `remindAt` epoch-ms, notes, `status`, `emailReminder`, optional linked entity) + owner-scoped CRUD at `/api/v1/reminder` (gated under ACTIVITY_CRUD). **5 service tests.**
- **Email STUB**: `EmailSender` + `LoggingEmailSender` (logs only), and a `@Scheduled ReminderEmailScheduler` (60s; `mtm.reminders.email-poll-ms`) that marks due email-reminders processed so nothing double-sends. `@EnableScheduling` added.
- **README documents** enabling real SMTP (add `spring-boot-starter-mail`, set `SPRING_MAIL_*`, drop in a `@Primary` `JavaMailSender`-backed `EmailSender` — no other changes).

## Frontend
- **`/reminders`** page: create (datetime picker + notes + *also email me*), list soonest-first, mark **done**/**dismiss**, delete.
- **`useReminderNotifications`** (app-wide): requests Web Notification permission and fires an **in-app toast + browser notification** for due reminders while the app is open (de-duped in localStorage). Nav link + route added.

Backend **94 tests green**; frontend build + `yarn test` green.