### PR TITLE
Reminder + task detail modals + profile avatar upload

### DIFF
--- a/frontend/src/Pages/Profile.js
+++ b/frontend/src/Pages/Profile.js
@@ -1,11 +1,12 @@
-import React, { useEffect, useState } from "react";
-import { FiUser, FiLock, FiStar, FiCheck } from "react-icons/fi";
+import React, { useEffect, useRef, useState } from "react";
+import { FiUser, FiLock, FiStar, FiCheck, FiCamera } from "react-icons/fi";
 import {
   cancelSubscription,
   changeUserPassword,
   getBilling,
   getUserProfile,
   startCheckout,
+  updateAvatar,
   updateUserDetails,
 } from "../service/ApiService";
 import { useConfirm } from "../components/ConfirmProvider";
@@ -17,6 +18,7 @@ const blankProfile = () => ({
   firstName: "",
   lastName: "",
   dateOfBirth: "",
+  avatarBase64: "",
 });
 
 const errorMessageFrom = (errorPayload) => {
@@ -77,6 +79,7 @@ function Profile({ setToastState }) {
           firstName: payload.firstName || "",
           lastName: payload.lastName || "",
           dateOfBirth: payload.dateOfBirth || "",
+          avatarBase64: payload.avatarBase64 || "",
         });
       }
     });
@@ -182,6 +185,28 @@ function Profile({ setToastState }) {
     });
   };
 
+  const avatarInputRef = useRef(null);
+
+  const onPickAvatar = (e) => {
+    const file = e.target.files && e.target.files[0];
+    if (!file) return;
+    if (file.size > 5 * 1024 * 1024) {
+      showError("Image must be at most 5 MB.");
+      e.target.value = "";
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = () => {
+      const dataUrl = reader.result;
+      updateAvatar({ avatarBase64: dataUrl }, (data, err) => {
+        if (err) return showError(errorMessageFrom(err));
+        setProfile((p) => ({ ...p, avatarBase64: dataUrl }));
+        showSuccess("Profile picture updated.");
+      });
+    };
+    reader.readAsDataURL(file);
+  };
+
   const initials = `${(profile.firstName || profile.username || "?")[0] || ""}${
     (profile.lastName || "")[0] || ""
   }`.toUpperCase();
@@ -204,9 +229,25 @@ function Profile({ setToastState }) {
   return (
     <div className="ui-page ui-fade-in mtm-max-w-3xl">
       <div className="mtm-flex mtm-items-center mtm-gap-4 mtm-mb-8">
-        <span className="mtm-inline-flex mtm-items-center mtm-justify-center mtm-h-14 mtm-w-14 mtm-rounded-2xl mtm-bg-gradient-to-br mtm-from-primary mtm-to-accent mtm-text-white mtm-font-display mtm-font-bold mtm-text-xl">
-          {initials || <FiUser />}
-        </span>
+        <div className="mtm-relative mtm-shrink-0">
+          <span className="mtm-inline-flex mtm-items-center mtm-justify-center mtm-h-16 mtm-w-16 mtm-rounded-2xl mtm-overflow-hidden mtm-bg-gradient-to-br mtm-from-primary mtm-to-accent mtm-text-white mtm-font-comic mtm-text-2xl mtm-border-[3px] mtm-border-ink mtm-shadow-comic-sm">
+            {profile.avatarBase64 ? (
+              <img src={profile.avatarBase64} alt="avatar" className="mtm-h-full mtm-w-full mtm-object-cover" />
+            ) : (
+              initials || <FiUser />
+            )}
+          </span>
+          <button
+            type="button"
+            onClick={() => avatarInputRef.current && avatarInputRef.current.click()}
+            className="mtm-absolute -mtm-bottom-1.5 -mtm-right-1.5 mtm-h-8 mtm-w-8 mtm-rounded-full mtm-bg-highlight mtm-border-2 mtm-border-ink mtm-flex mtm-items-center mtm-justify-center mtm-text-ink mtm-shadow-comic-sm hover:mtm-scale-110 mtm-transition-transform"
+            aria-label="Change photo"
+            title="Change photo"
+          >
+            <FiCamera size={14} />
+          </button>
+          <input ref={avatarInputRef} type="file" accept="image/*" className="mtm-hidden" onChange={onPickAvatar} />
+        </div>
         <div>
           <p className="ui-eyebrow">Account</p>
           <h1 className="mtm-text-3xl mtm-font-display mtm-font-bold mtm-text-content mtm-mt-1 mtm-mb-0">

--- a/frontend/src/Pages/ProjectDetail.js
+++ b/frontend/src/Pages/ProjectDetail.js
@@ -18,6 +18,9 @@ import {
   updateTask,
 } from "../service/ApiService";
 import { useConfirm } from "../components/ConfirmProvider";
+import Modal from "../components/Modal";
+import AttachmentPanel from "../components/AttachmentPanel";
+import { FiPaperclip } from "react-icons/fi";
 
 const COLUMNS = [
   { key: "TODO", label: "To do" },
@@ -94,6 +97,7 @@ function ProjectDetail({ setToastState }) {
   const { id } = useParams();
   const navigate = useNavigate();
   const confirm = useConfirm();
+  const [viewingTask, setViewingTask] = useState(null);
   const [project, setProject] = useState(null);
   const [tasks, setTasks] = useState([]);
   const [loading, setLoading] = useState(false);
@@ -222,9 +226,14 @@ function ProjectDetail({ setToastState }) {
                   {colTasks.map((t) => (
                     <div key={t.id} className="ui-card mtm-p-3.5">
                       <div className="mtm-flex mtm-items-start mtm-justify-between mtm-gap-2">
-                        <span className={`mtm-font-medium ${t.status === "DONE" ? "mtm-line-through ui-muted" : "mtm-text-content"}`}>
+                        <button
+                          type="button"
+                          onClick={() => setViewingTask(t)}
+                          title="View details & files"
+                          className={`mtm-font-medium mtm-text-left hover:mtm-underline ${t.status === "DONE" ? "mtm-line-through ui-muted" : "mtm-text-content"}`}
+                        >
                           {t.name}
-                        </span>
+                        </button>
                         <button className="mtm-text-muted hover:mtm-text-danger mtm-shrink-0" onClick={() => remove(t)} aria-label="Delete">
                           <FiTrash2 size={14} />
                         </button>
@@ -267,6 +276,43 @@ function ProjectDetail({ setToastState }) {
           })}
         </div>
       )}
+
+      <Modal
+        open={!!viewingTask}
+        onClose={() => setViewingTask(null)}
+        title={viewingTask ? viewingTask.name : ""}
+        icon={<FiPaperclip />}
+        footer={<button className="ui-btn ui-btn-primary" onClick={() => setViewingTask(null)}>Done</button>}
+      >
+        {viewingTask && (
+          <div className="mtm-flex mtm-flex-col mtm-gap-4">
+            <div className="mtm-flex mtm-flex-wrap mtm-gap-2">
+              <span className="ui-chip">{(viewingTask.status || "TODO").replace("_", " ")}</span>
+              <span className={`mtm-text-xs mtm-px-2 mtm-py-0.5 mtm-rounded-full mtm-border ${PRIORITY_CLASS[viewingTask.priority] || PRIORITY_CLASS.LOW}`}>
+                {viewingTask.priority}
+              </span>
+              {viewingTask.dueDate && (
+                <span className="ui-chip"><FiCalendar size={12} /> {viewingTask.dueDate}</span>
+              )}
+            </div>
+            {viewingTask.description && (
+              <p className="mtm-text-content mtm-font-medium mtm-m-0">{viewingTask.description}</p>
+            )}
+            <div>
+              <h3 className="mtm-font-comic mtm-text-lg mtm-text-content mtm-mb-2 mtm-flex mtm-items-center mtm-gap-2">
+                <FiChevronDown /> Sub-tasks
+              </h3>
+              <SubTasks parentId={viewingTask.id} showError={showError} />
+            </div>
+            <div>
+              <h3 className="mtm-font-comic mtm-text-lg mtm-text-content mtm-mb-2 mtm-flex mtm-items-center mtm-gap-2">
+                <FiPaperclip /> Files &amp; images
+              </h3>
+              <AttachmentPanel parentType="TASK" parentId={viewingTask.id} onError={showError} />
+            </div>
+          </div>
+        )}
+      </Modal>
     </div>
   );
 }

--- a/frontend/src/Pages/Reminders.js
+++ b/frontend/src/Pages/Reminders.js
@@ -15,6 +15,9 @@ import {
   updateReminder,
 } from "../service/ApiService";
 import { useConfirm } from "../components/ConfirmProvider";
+import Modal from "../components/Modal";
+import AttachmentPanel from "../components/AttachmentPanel";
+import { FiPaperclip } from "react-icons/fi";
 
 const errorMessageFrom = (e) =>
   (e && e.error && e.error.message) || (e && e.message) || "Something went wrong.";
@@ -43,6 +46,7 @@ function Reminders({ setToastState }) {
   const [loading, setLoading] = useState(false);
   const [creating, setCreating] = useState(false);
   const [form, setForm] = useState({ title: "", remindAtLocal: "", notes: "", emailReminder: false });
+  const [viewing, setViewing] = useState(null);
   const confirm = useConfirm();
 
   const showError = (m) =>
@@ -158,7 +162,12 @@ function Reminders({ setToastState }) {
           const overdue = r.status === "PENDING" && r.remindAt && r.remindAt <= Date.now();
           return (
             <li key={r.id} className="ui-card-flat mtm-p-4 mtm-flex mtm-flex-col sm:mtm-flex-row sm:mtm-justify-between sm:mtm-items-center mtm-gap-3">
-              <div className="mtm-flex mtm-items-start mtm-gap-3 mtm-min-w-0">
+              <button
+                type="button"
+                onClick={() => setViewing(r)}
+                title="View details & files"
+                className="mtm-flex mtm-items-start mtm-gap-3 mtm-min-w-0 mtm-flex-1 mtm-text-left hover:mtm-opacity-90 mtm-transition-opacity"
+              >
                 <span className={`ui-icon-tile mtm-shrink-0 mtm-mt-0.5 ${overdue ? "mtm-text-danger" : ""}`}>
                   <FiBell size={17} />
                 </span>
@@ -175,9 +184,9 @@ function Reminders({ setToastState }) {
                       <span className="mtm-inline-flex mtm-items-center mtm-gap-1"><FiMail size={12} /> email</span>
                     )}
                   </div>
-                  {r.notes && <div className="mtm-text-sm ui-muted mtm-mt-1">{r.notes}</div>}
+                  {r.notes && <div className="mtm-text-sm ui-muted mtm-mt-1 mtm-line-clamp-1">{r.notes}</div>}
                 </div>
-              </div>
+              </button>
               <div className="mtm-flex mtm-gap-2 mtm-shrink-0">
                 {r.status === "PENDING" && (
                   <>
@@ -197,6 +206,32 @@ function Reminders({ setToastState }) {
           );
         })}
       </ul>
+
+      <Modal
+        open={!!viewing}
+        onClose={() => setViewing(null)}
+        title={viewing ? viewing.title : ""}
+        icon={<FiBell />}
+        footer={<button className="ui-btn ui-btn-primary" onClick={() => setViewing(null)}>Done</button>}
+      >
+        {viewing && (
+          <div className="mtm-flex mtm-flex-col mtm-gap-4">
+            <div className="mtm-flex mtm-flex-wrap mtm-gap-2">
+              <span className="ui-chip"><FiClock size={12} /> {fmt(viewing.remindAt)}</span>
+              <span className={`ui-chip ${STATUS_CHIP[viewing.status]}`}>{viewing.status}</span>
+              <span className="ui-chip">{relative(viewing.remindAt)}</span>
+              {viewing.emailReminder && <span className="ui-chip"><FiMail size={12} /> email</span>}
+            </div>
+            {viewing.notes && <p className="mtm-text-content mtm-font-medium mtm-m-0">{viewing.notes}</p>}
+            <div>
+              <h3 className="mtm-font-comic mtm-text-lg mtm-text-content mtm-mb-2 mtm-flex mtm-items-center mtm-gap-2">
+                <FiPaperclip /> Files &amp; images
+              </h3>
+              <AttachmentPanel parentType="REMINDER" parentId={viewing.id} onError={showError} />
+            </div>
+          </div>
+        )}
+      </Modal>
     </div>
   );
 }


### PR DESCRIPTION
Continues the modal + files work.

- **Reminder** rows and **task** cards are now clickable → **detail modals** with details + a files/images **AttachmentPanel** (`REMINDER`/`TASK`). The task modal also shows its **sub-tasks**.
- **Profile avatar upload** — a camera button on the avatar uploads via `PUT /user/avatar`; the header shows the picture (falls back to initials). 5 MB guard.

Frontend build + `yarn test` green.

> Next: DnD task board, Trash/Archive, Gantt.