### PR TITLE
fix(frontend): nested routes (/projects/:id) load assets — fixes dead 'Add task' button

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "proxy": "http://localhost:8080/mtm-dev/api/v1/",
-  "homepage": ".",
+  "homepage": "/",
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",


### PR DESCRIPTION
## Problem
The **"Add task" button (and every control) on a project detail page did nothing** when the page was loaded/refreshed directly at `/projects/:id`.

## Root cause
`frontend/package.json` had `"homepage": "."`, so CRA emitted **relative** asset URLs (`./static/js/main.js`). `/projects/:id` is the app's only two-segment route, so `./static/...` resolves against `/projects/` → `/projects/static/...`, which 404s. Nginx's SPA fallback then returns `index.html` (HTML) for the bundle request, the browser tries to execute HTML as JS (`Unexpected token '<'`), **React never mounts**, and the whole page is inert.

Single-segment routes (`/activity`, `/projects`) resolve `./` to root, so they were unaffected — which is exactly why only *existing projects* (the `/projects/:id` detail view) broke.

## Fix
Set `"homepage": "/"` so assets emit as absolute `/static/...` and load at any route depth.

## Verification
- Built `index.html` now references `/static/js/main.*.js` (absolute).
- Headless (puppeteer) full-load of `/projects/:id`: React mounts, `New task` → fill → `Create task` → `POST /task` 200 → task renders. No page errors.
- `yarn test` green; `yarn build` green.